### PR TITLE
[pulsar connectors] Upgrade dependencies to get rid of multiple CVEs

### DIFF
--- a/connector-luna/build.gradle
+++ b/connector-luna/build.gradle
@@ -31,6 +31,19 @@ dependencies {
     compileOnly("com.datastax.oss:pulsar-io-common:${lunaVersion}")
     compileOnly("com.datastax.oss:pulsar-io-core:${lunaVersion}")
 
+    constraints {
+        implementation("ch.qos.logback:logback-classic:${logbackVersion}")
+        implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}")
+        implementation("com.github.jnr:jnr-posix:${jnrVersion}")
+        implementation("io.netty:netty-handler:${nettyVersion}")
+        implementation("io.netty:netty-transport-native-epoll:${nettyVersion}")
+        implementation("io.netty:netty-transport-native-unix-common:${nettyVersion}")
+        implementation("io.netty:netty-codec-haproxy:${nettyVersion}")
+        implementation("io.netty:netty-tcnative-boringssl-static:${nettyTcNativeVersion}")
+        implementation("org.apache.commons:commons-compress:${commonCompressVersion}")
+        implementation("com.google.code.gson:gson:${gsonVersion}")
+    }
+
     testRuntimeOnly("org.slf4j:slf4j-simple:${slf4jVersion}")
     testRuntimeOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/connector-pulsar/build.gradle
+++ b/connector-pulsar/build.gradle
@@ -36,6 +36,18 @@ dependencies {
     compileOnly("${pulsarGroup}:pulsar-io-common:${pulsarVersion}")
     compileOnly("${pulsarGroup}:pulsar-io-core:${pulsarVersion}")
 
+    constraints {
+        implementation("ch.qos.logback:logback-classic:${logbackVersion}")
+        implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}")
+        implementation("com.github.jnr:jnr-posix:${jnrVersion}")
+        implementation("io.netty:netty-handler:${nettyVersion}")
+        implementation("io.netty:netty-transport-native-epoll:${nettyVersion}")
+        implementation("io.netty:netty-transport-native-unix-common:${nettyVersion}")
+        implementation("io.netty:netty-codec-haproxy:${nettyVersion}")
+        implementation("io.netty:netty-tcnative-boringssl-static:${nettyTcNativeVersion}")
+        implementation("org.apache.commons:commons-compress:${commonCompressVersion}")
+    }
+
     testRuntimeOnly("org.slf4j:slf4j-simple:${slf4jVersion}")
     testRuntimeOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,14 @@ caffeineVersion=2.8.8
 guavaVersion=30.1-jre
 messagingConnectorsCommonsVersion=1.0.14
 slf4jVersion=1.7.30
+# pulsar connector
+logbackVersion=1.2.9
+jacksonDatabindVersion=2.12.6
+jnrVersion=3.1.15
+nettyVersion=4.1.72.Final
+nettyTcNativeVersion=2.0.46.Final
+commonCompressVersion=1.21
+gsonVersion=2.8.9
 
 # cassandra settings for docker images
 commitlog_sync_period_in_ms=2000


### PR DESCRIPTION
Running Sonatype IQ server scan against pulsar-connector.nar and luna-connector.nar shows up some dependencies with CVE. See the report: [lunastreaming-ci-Release-20220117-142433.pdf](https://github.com/datastax/cdc-apache-cassandra/files/7882669/lunastreaming-ci-Release-20220117-142433.pdf)


## Changes 

Forced transitive dependencies version:
* logback 1.2.9
* jackson Databind 2.12.6
* jnr 3.1.15
* netty 4.1.72.Final
* nettyTcNative 2.0.46.Final
* commonCompress 1.21
* gson 2.8.9

This affects the connector for Luna Streaming 2.7 and Luna Streaming/Pulsar 2.8