### PR TITLE
Generate docs with the project version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,12 @@ jobs:
           distribution: 'adopt'
       - name: Generate agent settings documentation
         run:  ./gradlew agent:run --args="../docs/modules/ROOT/pages"
-      - name: Generate connector settings documentation
-        run: ./gradlew docs:run --args="modules/ROOT/pages"
 
+      - name: Generate connector settings documentation
+        run: ./gradlew docs:antoraConfig
+
+      - name: Generate Antora configuration in antora.yml
+        run: ./gradlew docs:run --args="modules/ROOT/pages"
       - name: Run Antora
         uses: kameshsampath/antora-site-action@v0.2.4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ out/
 .factorypath
 AsciiDocGenerator.class
 bin/
+docs/antora.yml

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -20,6 +20,15 @@ Install Antora:
 npm i -g @antora/cli@2.3 @antora/site-generator-default@2.3
 ----
 
+== Create the antora config file
+
+Generate the antory.yaml file using the project version:
+
+[source,bash]
+----
+./gradlew docs:antoraConfig
+----
+
 == Generating and viewing the HTML output locally
 
 The docs can be generated locally during development, to check work.

--- a/docs/antora-template.yml
+++ b/docs/antora-template.yml
@@ -1,7 +1,7 @@
 name: cdc-apache-cassandra
 title: DataStax CDC for Apache Cassandra(R) Documentation
-version: "1.0.2"
-display_version: "1.0.2"
+version: "${version}"
+display_version: "${version}"
 asciidoc:
   attributes:
     cdc_cass_first: 'DataStax CDC for Apache Cassandra®'

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -17,4 +17,10 @@ application {
     mainClassName = "org.apache.kafka.common.config.AsciiDocGenerator"
 }
 
+task antoraConfig(type: Copy) {
+    from 'antora-template.yml'
+    rename 'antora-template.yml', 'antora.yml'
+    destinationDir projectDir
+    expand version: version
+}
 


### PR DESCRIPTION
Generate the docs/antora.yml config from a template file using a gradle task to update the project version.