### PR TITLE
[pulsar connector] Do not use DS driver core shaded

### DIFF
--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(':commons')
     implementation("com.github.ben-manes.caffeine:caffeine:${caffeineVersion}")
     implementation("io.vavr:vavr:${vavrVersion}")
-    implementation "com.datastax.oss:java-driver-core-shaded:${ossDriverVersion}"
+    implementation "com.datastax.oss:java-driver-core:${ossDriverVersion}"
     implementation "com.datastax.oss:java-driver-query-builder:${ossDriverVersion}"
     implementation("org.apache.kafka:connect-api:${kafkaVersion}")
     implementation("com.google.guava:guava:${guavaVersion}")


### PR DESCRIPTION
Fix #67

Connector is using `com.datastax.oss:java-driver-core-shaded` but it is not needed since the non-shaded version is already imported by another dependency