### PR TITLE
Tests: use SortedLedgerStorage in order to not use RocksDB, not compatible with Mac M1

### DIFF
--- a/testcontainers/src/main/java/com/datastax/testcontainers/PulsarContainer.java
+++ b/testcontainers/src/main/java/com/datastax/testcontainers/PulsarContainer.java
@@ -54,7 +54,7 @@ public class PulsarContainer<SELF extends PulsarContainer<SELF>> extends Generic
         withCommand("/bin/bash", "-c", standaloneBaseCommand);
 
         // use standard BooKeeper LedgerStorage, not based on RocksDB, in order to see tests running M1
-        withEnv("PULSAR_PREFIX_ledgerStorageClass", "org.apache.bookkeeper.bookie.SortedLedgerStorage")
+        withEnv("PULSAR_PREFIX_ledgerStorageClass", "org.apache.bookkeeper.bookie.SortedLedgerStorage");
 
         withLogConsumer(o -> {
             log.info("[{}] {}", getContainerName(), o.getUtf8String().trim());


### PR DESCRIPTION
This is a proof-of-concept patch to try running tests on Mac M1.
There is a problem with the version of RocksDB bundled with Pulsar.

We can disable DbLedgerStorage, enabled by default in Pulsar, and use the standard SortedLedgerStorage, that does not use RocksDB