### PR TITLE
Add JSON support for Cassandra source

### DIFF
--- a/agent/src/main/java/com/datastax/oss/cdc/agent/AbstractPulsarMutationSender.java
+++ b/agent/src/main/java/com/datastax/oss/cdc/agent/AbstractPulsarMutationSender.java
@@ -18,12 +18,11 @@ package com.datastax.oss.cdc.agent;
 import com.datastax.oss.cdc.CqlLogicalTypes;
 import com.datastax.oss.cdc.MutationValue;
 import com.datastax.oss.cdc.agent.exceptions.CassandraConnectorSchemaException;
-import com.datastax.oss.cdc.AvroSchemaWrapper;
+import com.datastax.oss.cdc.NativeSchemaWrapper;
 import com.datastax.oss.cdc.Murmur3MessageRouter;
 import com.datastax.oss.cdc.Constants;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Conversions;
@@ -36,6 +35,7 @@ import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -187,7 +187,7 @@ public abstract class AbstractPulsarMutationSender<T> implements MutationSender<
         return producers.computeIfAbsent(topicAndProducerName.topicName, k -> {
             try {
                 org.apache.pulsar.client.api.Schema<KeyValue<byte[], MutationValue>> keyValueSchema = org.apache.pulsar.client.api.Schema.KeyValue(
-                        new AvroSchemaWrapper(getAvroKeySchema(tm).schema),
+                        new NativeSchemaWrapper(getAvroKeySchema(tm).schema, SchemaType.AVRO),
                         org.apache.pulsar.client.api.Schema.AVRO(MutationValue.class),
                         KeyValueEncodingType.SEPARATED);
                 ProducerBuilder<KeyValue<byte[], MutationValue>> producerBuilder = client.newProducer(keyValueSchema)

--- a/commons/src/main/java/com/datastax/oss/cdc/NativeSchemaWrapper.java
+++ b/commons/src/main/java/com/datastax/oss/cdc/NativeSchemaWrapper.java
@@ -25,18 +25,21 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Optional;
 
-public class AvroSchemaWrapper implements org.apache.pulsar.client.api.Schema<byte[]> {
+public class NativeSchemaWrapper implements org.apache.pulsar.client.api.Schema<byte[]> {
 
-    private final SchemaInfo schemaInfo;
-    private final Schema nativeAvroSchema;
+    private final SchemaInfo pulsarSchemaInfo;
+    private final Schema nativeSchema;
 
-    public AvroSchemaWrapper(Schema nativeAvroSchema) {
-        this.nativeAvroSchema = nativeAvroSchema;
-        this.schemaInfo = SchemaInfoImpl.builder()
-                .schema(nativeAvroSchema.toString(false).getBytes(StandardCharsets.UTF_8))
+    private final SchemaType pulsarSchemaType;
+
+    public NativeSchemaWrapper(Schema nativeSchema, SchemaType pulsarSchemaType) {
+        this.nativeSchema = nativeSchema;
+        this.pulsarSchemaType = pulsarSchemaType;
+        this.pulsarSchemaInfo = SchemaInfoImpl.builder()
+                .schema(nativeSchema.toString(false).getBytes(StandardCharsets.UTF_8))
                 .properties(new HashMap<>())
-                .type(SchemaType.AVRO)
-                .name(nativeAvroSchema.getName())
+                .type(pulsarSchemaType)
+                .name(nativeSchema.getName())
                 .build();
     }
 
@@ -47,12 +50,12 @@ public class AvroSchemaWrapper implements org.apache.pulsar.client.api.Schema<by
 
     @Override
     public SchemaInfo getSchemaInfo() {
-        return schemaInfo;
+        return pulsarSchemaInfo;
     }
 
     @Override
-    public AvroSchemaWrapper clone() {
-        return new AvroSchemaWrapper(nativeAvroSchema);
+    public NativeSchemaWrapper clone() {
+        return new NativeSchemaWrapper(nativeSchema, pulsarSchemaType);
     }
 
     @Override
@@ -92,6 +95,6 @@ public class AvroSchemaWrapper implements org.apache.pulsar.client.api.Schema<by
 
     @Override
     public Optional<Object> getNativeSchema() {
-        return Optional.of(nativeAvroSchema);
+        return Optional.of(nativeSchema);
     }
 }

--- a/connector/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
@@ -675,6 +675,12 @@ public class CassandraSourceConnectorConfig {
         DRIVER
     }
 
+    public enum OutputFormat {
+        KEY_VALUE_AVRO,
+        KEY_VALUE_JSON,
+        JSON // Both key and value are encoded in the message value. The message key is also populated with a JSON string.
+    }
+
     public IgnoreErrorsPolicy getIgnoreErrors() {
         String ignoreErrors = globalConfig.getString(IGNORE_ERRORS);
         if ("none".equalsIgnoreCase(ignoreErrors)) {
@@ -728,20 +734,30 @@ public class CassandraSourceConnectorConfig {
         return authConfig;
     }
 
-    public String getOutputFormat() {
-        return globalConfig.getString(OUTPUT_FORMAT);
+    public OutputFormat getOutputFormat() {
+        switch (globalConfig.getString(OUTPUT_FORMAT)) {
+            case "key-value-avro":
+                return OutputFormat.KEY_VALUE_AVRO;
+            case "key-value-json":
+                return OutputFormat.KEY_VALUE_JSON;
+            case "json":
+                return OutputFormat.JSON;
+            default:
+                throw new IllegalArgumentException("Illegal output format: " + globalConfig.getString(OUTPUT_FORMAT));
+        }
     }
 
     public boolean isAvroOutputFormat() {
-        return globalConfig.getString(OUTPUT_FORMAT).contains("avro");
+        return getOutputFormat() == OutputFormat.KEY_VALUE_AVRO;
     }
 
     public boolean isJsonOutputFormat() {
-        return globalConfig.getString(OUTPUT_FORMAT).contains("json");
+        OutputFormat format = getOutputFormat();
+        return format == OutputFormat.KEY_VALUE_JSON || format == OutputFormat.JSON;
     }
 
     public boolean isJsonOnlyOutputFormat() {
-        return globalConfig.getString(OUTPUT_FORMAT).equals("json");
+        return getOutputFormat() == OutputFormat.JSON;
     }
 
     @Nullable

--- a/connector/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
@@ -80,6 +80,8 @@ public class CassandraSourceConnectorConfig {
     public static final String PORT_OPT = "port";
 
     public static final String DC_OPT = "loadBalancing.localDc";
+
+    public static final String OUTPUT_FORMAT = "outputFormat";
     static final String LOCAL_DC_DRIVER_SETTING =
             withDriverPrefix(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER);
 
@@ -305,7 +307,17 @@ public class CassandraSourceConnectorConfig {
                             ConfigDef.Type.STRING,
                             "",
                             ConfigDef.Importance.HIGH,
-                            "The location of the cloud secure bundle used to connect to Datastax Astra DB.");
+                            "The location of the cloud secure bundle used to connect to Datastax Astra DB.")
+                    .define(OUTPUT_FORMAT,
+                            ConfigDef.Type.STRING,
+                            "key-value-avro",
+                            ConfigDef.ValidString.in("key-value-avro", "key-value-json", "json"),
+                            ConfigDef.Importance.LOW,
+                            "The format of the messages on the data topic. "
+                                    + "Valid values are: "
+                                    + "key-value-avro (encodes the key and value separately, both in AVRO format), "
+                                    + "key-value-json (encodes the key and value separately, both in JSON format), "
+                                    + "json (key and value are encoded together in single JSON object)" );
     private static final Function<String, String> TO_SECONDS_CONVERTER =
             v -> String.format("%s seconds", v);
 
@@ -714,6 +726,22 @@ public class CassandraSourceConnectorConfig {
 
     public AuthenticatorConfig getAuthenticatorConfig() {
         return authConfig;
+    }
+
+    public String getOutputFormat() {
+        return globalConfig.getString(OUTPUT_FORMAT);
+    }
+
+    public boolean isAvroOutputFormat() {
+        return globalConfig.getString(OUTPUT_FORMAT).contains("avro");
+    }
+
+    public boolean isJsonOutputFormat() {
+        return globalConfig.getString(OUTPUT_FORMAT).contains("json");
+    }
+
+    public boolean isJsonOnlyOutputFormat() {
+        return globalConfig.getString(OUTPUT_FORMAT).equals("json");
     }
 
     @Nullable

--- a/connector/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
@@ -350,7 +350,7 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
         try {
             List<ColumnMetadata> columns = tableMetadata.getColumns().values().stream()
                     // include primary keys in the json only output format options
-                    // TODO: PERF: Infuse the key values returned from the mutation keys instead of reading from DB
+                    // TODO: PERF: Infuse the key values instead of reading from DB https://github.com/datastax/cdc-apache-cassandra/issues/84
                     .filter(c -> config.isJsonOnlyOutputFormat() ? true : !tableMetadata.getPrimaryKey().contains(c))
                     .filter(c -> !columnPattern.isPresent() || columnPattern.get().matcher(c.getName().asInternal()).matches())
                     .collect(Collectors.toList());

--- a/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractGenericConverter.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractGenericConverter.java
@@ -26,21 +26,32 @@ import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.datastax.oss.pulsar.source.Converter;
+import com.google.common.net.InetAddresses;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.avro.util.internal.JacksonUtils;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.schema.*;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.FieldSchemaBuilder;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 
 @Slf4j
-public abstract class AbstractGenericConverter implements Converter<GenericRecord, GenericRecord, Row, GenericRecord> {
+public abstract class AbstractGenericConverter implements Converter<GenericRecord, GenericRecord, Row, List<Object>> {
 
     public final GenericSchema<GenericRecord> schema;
     public final SchemaInfo schemaInfo;
@@ -325,28 +336,44 @@ public abstract class AbstractGenericConverter implements Converter<GenericRecor
     }
 
     /**
-     * Convert GenericRecord from the dirty topic to a GenericRecord of the data topic that are sink ready.
+     * Convert GenericRecord to primary key column values.
      *
-     * @param genericRecord the avro key generic record read from the dirty topic
-     * @return schema type encoded key (e.g. JSON)
+     * @param genericRecord
+     * @return list of primary key column values
      */
     @Override
-    public GenericRecord fromConnectData(GenericRecord genericRecord) {
-        if (genericRecord.getSchemaType() == this.schemaType) {
-            return genericRecord;
-        }
-
-        if (genericRecord.getSchemaType() == SchemaType.AVRO) {
-            GenericRecordBuilder builder = this.schema.newRecordBuilder();
-            for (Field field: genericRecord.getFields()) {
-                // handle nested AVRO objects
-                builder.set(field, JacksonUtils.toJsonNode(genericRecord.getField(field)));
+    public List<Object> fromConnectData(GenericRecord genericRecord) {
+        List<Object> pk = new ArrayList<>(tableMetadata.getPrimaryKey().size());
+        for(ColumnMetadata cm : tableMetadata.getPrimaryKey()) {
+            Object value = genericRecord.getField(cm.getName().asInternal());
+            if (value != null) {
+                switch (cm.getType().getProtocolCode()) {
+                    case ProtocolConstants.DataType.INET:
+                        value = InetAddresses.forString((String)value);
+                        break;
+                    case ProtocolConstants.DataType.UUID:
+                    case ProtocolConstants.DataType.TIMEUUID:
+                        value = UUID.fromString((String) value);
+                        break;
+                    case ProtocolConstants.DataType.TINYINT:
+                        value = ((Integer) value).byteValue();
+                        break;
+                    case ProtocolConstants.DataType.SMALLINT:
+                        value = ((Integer) value).shortValue();
+                        break;
+                    case ProtocolConstants.DataType.TIMESTAMP:
+                        value = Instant.ofEpochMilli((long) value);
+                        break;
+                    case ProtocolConstants.DataType.DATE:
+                        value = LocalDate.ofEpochDay((int) value);
+                        break;
+                    case ProtocolConstants.DataType.TIME:
+                        value = LocalTime.ofNanoOfDay( ((Integer)value).longValue() * 1000000);
+                        break;
+                }
             }
-            return builder.build();
+            pk.add(value);
         }
-
-        throw new UnsupportedOperationException(
-                String.format("Cannot convert from %s to a generic record with schema type %s" ,
-                genericRecord, this.schemaType));
+        return pk;
     }
 }

--- a/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractNativeConverter.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractNativeConverter.java
@@ -58,6 +58,7 @@ public abstract class AbstractNativeConverter<T> implements Converter<byte[], Ge
                             Schema collectionSchema = dataTypeSchema(ksm, cm.getType());
                             subSchemas.put(field.name(), collectionSchema);
                             log.info("Add collection schema {}={}", field.name(), collectionSchema);
+                            break;
                     }
                 }
             }

--- a/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractNativeConverter.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractNativeConverter.java
@@ -1,0 +1,231 @@
+package com.datastax.oss.pulsar.source.converters;
+
+import com.datastax.oss.cdc.CqlLogicalTypes;
+import com.datastax.oss.cdc.NativeSchemaWrapper;
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.ListType;
+import com.datastax.oss.driver.api.core.type.MapType;
+import com.datastax.oss.driver.api.core.type.SetType;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.pulsar.source.Converter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An abstract class for native schema converters. Pulsar schemas (Avro and JSON) are represented in Avro with the only
+ * difference in the type field.
+ * @param <T> The desired type of the key representation. For example the Avro converter, the desired type is a List of
+ *           PK columns to because to query C* table. However, the actual keys are copied as is from the mutation topic.
+ *           In JSON only format, because the key will be embedded in the payload, the subclass may wish to convert to
+ *           pulsar's GenericRecord or serialized Jackson node
+ */
+@Slf4j
+public abstract class AbstractNativeConverter<T> implements Converter<byte[], GenericRecord, Row, T> {
+    public final org.apache.pulsar.client.api.Schema<byte[]> pulsarSchema;
+    public final Schema nativeSchema;
+    public final TableMetadata tableMetadata;
+    public final Map<String, Schema> subSchemas = new HashMap<>();
+
+    public AbstractNativeConverter(KeyspaceMetadata ksm, TableMetadata tm, List<ColumnMetadata> columns) {
+        this.tableMetadata = tm;
+        String keyspaceAndTable = ksm.getName() + "." + tm.getName();
+        List<Schema.Field> fields = new ArrayList<>();
+        for(ColumnMetadata cm : columns) {
+            boolean isPartitionKey = tm.getPartitionKey().contains(cm);
+            if (isSupportedCqlType(cm.getType())) {
+                Schema.Field field = fieldSchema(ksm, cm.getName().toString(), cm.getType(), !isPartitionKey);
+                if (field != null) {
+                    fields.add(field);
+                    switch(cm.getType().getProtocolCode()) {
+                        case ProtocolConstants.DataType.LIST:
+                        case ProtocolConstants.DataType.SET:
+                        case ProtocolConstants.DataType.MAP:
+                            Schema collectionSchema = dataTypeSchema(ksm, cm.getType());
+                            subSchemas.put(field.name(), collectionSchema);
+                            log.info("Add collection schema {}={}", field.name(), collectionSchema);
+                    }
+                }
+            }
+        }
+        this.nativeSchema = Schema.createRecord(keyspaceAndTable, "Table " + keyspaceAndTable, ksm.getName().asInternal(), false, fields);
+        this.pulsarSchema = new NativeSchemaWrapper(nativeSchema, getSchemaType());
+        if (log.isInfoEnabled()) {
+            log.info("schema={}", this.nativeSchema);
+            for(Map.Entry<String, Schema> entry : subSchemas.entrySet()) {
+                log.info("type={} schema={}", entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    abstract SchemaType getSchemaType();
+
+    @Override
+    public org.apache.pulsar.client.api.Schema<byte[]> getSchema() {
+        return this.pulsarSchema;
+    }
+
+    boolean isSupportedCqlType(DataType dataType) {
+        switch (dataType.getProtocolCode()) {
+            case ProtocolConstants.DataType.ASCII:
+            case ProtocolConstants.DataType.VARCHAR:
+            case ProtocolConstants.DataType.BOOLEAN:
+            case ProtocolConstants.DataType.BLOB:
+            case ProtocolConstants.DataType.DATE:
+            case ProtocolConstants.DataType.TIME:
+            case ProtocolConstants.DataType.TIMESTAMP:
+            case ProtocolConstants.DataType.UUID:
+            case ProtocolConstants.DataType.TIMEUUID:
+            case ProtocolConstants.DataType.TINYINT:
+            case ProtocolConstants.DataType.SMALLINT:
+            case ProtocolConstants.DataType.INT:
+            case ProtocolConstants.DataType.BIGINT:
+            case ProtocolConstants.DataType.DOUBLE:
+            case ProtocolConstants.DataType.FLOAT:
+            case ProtocolConstants.DataType.INET:
+            case ProtocolConstants.DataType.UDT:
+            case ProtocolConstants.DataType.VARINT:
+            case ProtocolConstants.DataType.DECIMAL:
+            case ProtocolConstants.DataType.DURATION:
+            case ProtocolConstants.DataType.LIST:
+            case ProtocolConstants.DataType.SET:
+            case ProtocolConstants.DataType.MAP:
+                return true;
+        }
+        return false;
+    }
+
+    Schema.Field fieldSchema(KeyspaceMetadata ksm,
+                             String fieldName,
+                             DataType dataType,
+                             boolean optional) {
+        return fieldSchema(ksm, fieldName, dataTypeSchema(ksm, dataType), optional);
+    }
+
+    Schema.Field fieldSchema(KeyspaceMetadata ksm,
+                             String fieldName,
+                             Schema schema,
+                             boolean optional) {
+        Schema.Field fieldSchema = new Schema.Field(fieldName, schema);
+        if (optional) {
+            fieldSchema = new Schema.Field(fieldName, SchemaBuilder.unionOf().nullType().and().type(fieldSchema.schema()).endUnion(), null, Schema.Field.NULL_DEFAULT_VALUE);
+        }
+        return fieldSchema;
+    }
+
+    Schema dataTypeSchema(KeyspaceMetadata ksm, DataType dataType) {
+        switch(dataType.getProtocolCode()) {
+            case ProtocolConstants.DataType.INET:
+            case ProtocolConstants.DataType.ASCII:
+            case ProtocolConstants.DataType.VARCHAR:
+                return org.apache.avro.Schema.create(Schema.Type.STRING);
+            case ProtocolConstants.DataType.BLOB:
+                return org.apache.avro.Schema.create(Schema.Type.BYTES);
+            case ProtocolConstants.DataType.TINYINT:
+            case ProtocolConstants.DataType.SMALLINT:
+            case ProtocolConstants.DataType.INT:
+                return org.apache.avro.Schema.create(Schema.Type.INT);
+            case ProtocolConstants.DataType.BIGINT:
+                return org.apache.avro.Schema.create(Schema.Type.LONG);
+            case ProtocolConstants.DataType.BOOLEAN:
+                return org.apache.avro.Schema.create(Schema.Type.BOOLEAN);
+            case ProtocolConstants.DataType.FLOAT:
+                return org.apache.avro.Schema.create(Schema.Type.FLOAT);
+            case ProtocolConstants.DataType.DOUBLE:
+                return org.apache.avro.Schema.create(Schema.Type.DOUBLE);
+            case ProtocolConstants.DataType.TIMESTAMP:
+                return CqlLogicalTypes.timestampMillisType;
+            case ProtocolConstants.DataType.DATE:
+                return CqlLogicalTypes.dateType;
+            case ProtocolConstants.DataType.TIME:
+                return CqlLogicalTypes.timeMicrosType;
+            case ProtocolConstants.DataType.UDT:
+                return buildUDTSchema(ksm, dataType.asCql(false, true), false);
+            case ProtocolConstants.DataType.UUID:
+            case ProtocolConstants.DataType.TIMEUUID:
+                return CqlLogicalTypes.uuidType;
+            case ProtocolConstants.DataType.VARINT:
+                return CqlLogicalTypes.varintType;
+            case ProtocolConstants.DataType.DECIMAL:
+                return CqlLogicalTypes.decimalType;
+            case ProtocolConstants.DataType.DURATION:
+                return CqlLogicalTypes.durationType;
+            case ProtocolConstants.DataType.LIST:
+                ListType listType = (ListType) dataType;
+                return org.apache.avro.Schema.createArray(dataTypeSchema(ksm, listType.getElementType()));
+            case ProtocolConstants.DataType.SET:
+                SetType setType = (SetType) dataType;
+                return org.apache.avro.Schema.createArray(dataTypeSchema(ksm, setType.getElementType()));
+            case ProtocolConstants.DataType.MAP:
+                MapType mapType = (MapType) dataType;
+                return org.apache.avro.Schema.createMap(dataTypeSchema(ksm, mapType.getValueType()));
+            default:
+                throw new UnsupportedOperationException("Ignoring unsupported type=" + dataType.asCql(false, true));
+        }
+    }
+
+    Schema buildUDTSchema(KeyspaceMetadata ksm, String typeName, boolean optional) {
+        UserDefinedType userDefinedType = ksm.getUserDefinedType(CqlIdentifier.fromCql(typeName.substring(typeName.indexOf(".") + 1)))
+                .orElseThrow(() -> new IllegalStateException("UDT " + typeName + " not found"));
+        List<Schema.Field> fieldSchemas = new ArrayList<>();
+        int i = 0;
+        for(CqlIdentifier field : userDefinedType.getFieldNames()) {
+            Schema.Field fieldSchema = fieldSchema(ksm, field.toString(), userDefinedType.getFieldTypes().get(i), optional);
+            if (fieldSchema != null) {
+                fieldSchemas.add(fieldSchema);
+                String path = typeName + "." + field.toString();
+                subSchemas.put(path, dataTypeSchema(ksm, userDefinedType.getFieldTypes().get(i)));
+            }
+            i++;
+        }
+        Schema udtSchema = Schema.createRecord(typeName, "CQL type " + typeName, ksm.getName().asInternal(), false, fieldSchemas);
+        subSchemas.put(typeName, udtSchema);
+        return udtSchema;
+    }
+
+    String stringify(DataType dataType, Object value) {
+        switch (dataType.getProtocolCode()) {
+            case ProtocolConstants.DataType.ASCII:
+            case ProtocolConstants.DataType.VARCHAR:
+            case ProtocolConstants.DataType.BOOLEAN:
+            case ProtocolConstants.DataType.DATE:
+            case ProtocolConstants.DataType.TIME:
+            case ProtocolConstants.DataType.TIMESTAMP:
+            case ProtocolConstants.DataType.UUID:
+            case ProtocolConstants.DataType.TIMEUUID:
+            case ProtocolConstants.DataType.TINYINT:
+            case ProtocolConstants.DataType.SMALLINT:
+            case ProtocolConstants.DataType.INT:
+            case ProtocolConstants.DataType.BIGINT:
+            case ProtocolConstants.DataType.DOUBLE:
+            case ProtocolConstants.DataType.FLOAT:
+            case ProtocolConstants.DataType.VARINT:
+            case ProtocolConstants.DataType.DECIMAL:
+            case ProtocolConstants.DataType.DURATION:
+            case ProtocolConstants.DataType.LIST:
+            case ProtocolConstants.DataType.SET:
+            case ProtocolConstants.DataType.MAP:
+                return value.toString();
+            case ProtocolConstants.DataType.INET:
+                return ((InetAddress)value).getHostAddress();
+            case ProtocolConstants.DataType.UDT:
+                //TODO: convert UDT to a map
+            default:
+                throw new UnsupportedOperationException("Unsupported type="+dataType.getProtocolCode()+" as key in a map");
+        }
+    }
+}

--- a/connector/src/main/java/com/datastax/oss/pulsar/source/converters/NativeJsonConverter.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/converters/NativeJsonConverter.java
@@ -1,0 +1,480 @@
+package com.datastax.oss.pulsar.source.converters;
+
+import com.datastax.oss.cdc.CqlLogicalTypes;
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.data.CqlDuration;
+import com.datastax.oss.driver.api.core.data.UdtValue;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.ListType;
+import com.datastax.oss.driver.api.core.type.MapType;
+import com.datastax.oss.driver.api.core.type.SetType;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Preconditions;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Conversion;
+import org.apache.avro.Conversions;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.specific.SpecificData;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class NativeJsonConverter extends AbstractNativeConverter<byte[]> {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final JsonNodeFactory jsonNodeFactory = JsonNodeFactory.withExactBigDecimals(true);
+
+    public NativeJsonConverter(KeyspaceMetadata ksm, TableMetadata tm, List<ColumnMetadata> columns) {
+        super(ksm, tm, columns);
+    }
+
+    @Override
+    SchemaType getSchemaType() {
+        return SchemaType.JSON;
+    }
+
+    @Override
+    public byte[] toConnectData(Row row) {
+        ObjectNode node = jsonNodeFactory.objectNode();
+        for(ColumnDefinition cm : row.getColumnDefinitions()) {
+            String fieldName = cm.getName().toString();
+            node.set(fieldName, toJson(row, cm));
+        }
+        return serializeJsonNode(node);
+    }
+
+    JsonNode toJson(Row row, ColumnDefinition cm) {
+        if (row.isNull(cm.getName())) {
+            return jsonNodeFactory.nullNode();
+        }
+        switch (cm.getType().getProtocolCode()) {
+            case ProtocolConstants.DataType.UUID:
+            case ProtocolConstants.DataType.TIMEUUID:
+                return jsonNodeFactory.textNode(row.getUuid(cm.getName()).toString());
+            case ProtocolConstants.DataType.ASCII:
+            case ProtocolConstants.DataType.VARCHAR:
+                return jsonNodeFactory.textNode(row.getString(cm.getName()));
+            case ProtocolConstants.DataType.TINYINT:
+                return jsonNodeFactory.numberNode((int) row.getByte(cm.getName()));
+            case ProtocolConstants.DataType.SMALLINT:
+                return jsonNodeFactory.numberNode((int) row.getShort(cm.getName()));
+            case ProtocolConstants.DataType.INT:
+                return jsonNodeFactory.numberNode(row.getInt(cm.getName()));
+            case ProtocolConstants.DataType.BIGINT:
+                return jsonNodeFactory.numberNode(row.getLong(cm.getName()));
+            case ProtocolConstants.DataType.INET:
+                return jsonNodeFactory.textNode(row.getInetAddress(cm.getName()).getHostAddress());
+            case ProtocolConstants.DataType.DOUBLE:
+                return jsonNodeFactory.numberNode(row.getDouble(cm.getName()));
+            case ProtocolConstants.DataType.FLOAT:
+                return jsonNodeFactory.numberNode(row.getFloat(cm.getName()));
+            case ProtocolConstants.DataType.BOOLEAN:
+                return jsonNodeFactory.booleanNode(row.getBoolean(cm.getName()));
+            case ProtocolConstants.DataType.TIMESTAMP:
+                return jsonNodeFactory.numberNode(row.getInstant(cm.getName()).toEpochMilli());
+            case ProtocolConstants.DataType.DATE: // Mimic Avro date (epoch days)
+                return jsonNodeFactory.numberNode((int) row.getLocalDate(cm.getName()).toEpochDay());
+            case ProtocolConstants.DataType.TIME: // Mimic Avro time (microseconds)
+                return jsonNodeFactory.numberNode (row.getLocalTime(cm.getName()).toNanoOfDay() / 1000);
+            case ProtocolConstants.DataType.BLOB:
+                return jsonNodeFactory.binaryNode(row.getByteBuffer(cm.getName()).array());
+            case ProtocolConstants.DataType.UDT:
+                return buildUDTValue(row.getUdtValue(cm.getName()));
+            case ProtocolConstants.DataType.DURATION:
+                return cqlDurationToJsonNode(row.getCqlDuration(cm.getName()));
+            case ProtocolConstants.DataType.DECIMAL:
+                return bigDecimalToJsonNode(row.getBigDecimal(cm.getName()));
+            case ProtocolConstants.DataType.VARINT:
+                Conversion<BigInteger> conversion = SpecificData.get().getConversionByClass(BigInteger.class);
+                ByteBuffer bytes = conversion.toBytes(row.getBigInteger(cm.getName()), CqlLogicalTypes.varintType, CqlLogicalTypes.CQL_VARINT_LOGICAL_TYPE);
+                return jsonNodeFactory.binaryNode(bytes.array());
+            case ProtocolConstants.DataType.LIST: {
+                ListType listType = (ListType) cm.getType();
+                String fieldName = cm.getName().toString();
+                org.apache.avro.Schema listSchema = subSchemas.get(fieldName);
+                List listValue = row.getList(fieldName, CodecRegistry.DEFAULT.codecFor(listType.getElementType()).getJavaType().getRawType());
+                log.info("field={} listSchema={} listValue={}", fieldName, listSchema, listValue);
+                return createArrayNode(listSchema, listValue);
+            }
+            case ProtocolConstants.DataType.SET: {
+                SetType setType = (SetType) cm.getType();
+                String fieldName = cm.getName().toString();
+                org.apache.avro.Schema setSchema = subSchemas.get(fieldName);
+                Set setValue = row.getSet(fieldName, CodecRegistry.DEFAULT.codecFor(setType.getElementType()).getJavaType().getRawType());
+                log.debug("field={} setSchema={} setValue={}", fieldName, setSchema, setValue);
+                return createArrayNode(setSchema, setValue);
+            }
+            case ProtocolConstants.DataType.MAP: {
+                MapType mapType = (MapType) cm.getType();
+                String fieldName = cm.getName().toString();
+                org.apache.avro.Schema mapSchema = subSchemas.get(fieldName);
+                Map<String, JsonNode> map = row.getMap(fieldName,
+                                CodecRegistry.DEFAULT.codecFor(mapType.getKeyType()).getJavaType().getRawType(),
+                                CodecRegistry.DEFAULT.codecFor(mapType.getValueType()).getJavaType().getRawType())
+                        .entrySet().stream().collect(Collectors.toMap(e -> stringify(mapType.getKeyType(), e.getKey()), e -> toJson(mapSchema.getValueType(), e.getValue())));
+                log.debug("field={} mapSchema={} mapValue={}", fieldName, mapSchema, map);
+                ObjectNode objectNode = jsonNodeFactory.objectNode();
+                map.forEach((k,v)->objectNode.set(k, v));
+                return objectNode;
+            }
+            default:
+                log.debug("Ignoring unsupported column name={} type={}", cm.getName(), cm.getType().asCql(false, true));
+        }
+
+        return null;
+    }
+
+    private JsonNode buildUDTValue(UdtValue udtValue) {
+        String typeName = udtValue.getType().getKeyspace() + "." + udtValue.getType().getName();
+        org.apache.avro.Schema udtSchema = subSchemas.get(typeName);
+        Preconditions.checkNotNull(udtSchema, "Schema not found for UDT=" + typeName);
+        Preconditions.checkState(udtSchema.getFields().size() > 0, "Schema UDT=" + typeName + " has no fields");
+        return buildUDTValue(udtSchema, udtValue);
+    }
+
+    JsonNode buildUDTValue(org.apache.avro.Schema udtSchema, UdtValue udtValue) {
+        String typeName = udtValue.getType().getKeyspace() + "." + udtValue.getType().getName();
+        List<String> fields = udtSchema.getFields().stream().map(org.apache.avro.Schema.Field::name).collect(Collectors.toList());
+        ObjectNode node = jsonNodeFactory.objectNode();
+        for(CqlIdentifier field : udtValue.getType().getFieldNames()) {
+            if (fields.contains(field.asInternal()) && !udtValue.isNull(field)) {
+                DataType dataType = udtValue.getType(field);
+                switch (dataType.getProtocolCode()) {
+                    case ProtocolConstants.DataType.UUID:
+                    case ProtocolConstants.DataType.TIMEUUID:
+                        node.put(field.toString(), udtValue.getUuid(field).toString());
+                        break;
+                    case ProtocolConstants.DataType.ASCII:
+                    case ProtocolConstants.DataType.VARCHAR:
+                        node.put(field.toString(), udtValue.getString(field));
+                        break;
+                    case ProtocolConstants.DataType.TINYINT:
+                        node.put(field.toString(), (int) udtValue.getByte(field));
+                        break;
+                    case ProtocolConstants.DataType.SMALLINT:
+                        node.put(field.toString(), (int) udtValue.getShort(field));
+                        break;
+                    case ProtocolConstants.DataType.INT:
+                        node.put(field.toString(), udtValue.getInt(field));
+                        break;
+                    case ProtocolConstants.DataType.INET:
+                        node.put(field.toString(), udtValue.getInetAddress(field).getHostAddress());
+                        break;
+                    case ProtocolConstants.DataType.BIGINT:
+                        node.put(field.toString(), udtValue.getLong(field));
+                        break;
+                    case ProtocolConstants.DataType.DOUBLE:
+                        node.put(field.toString(), udtValue.getDouble(field));
+                        break;
+                    case ProtocolConstants.DataType.FLOAT:
+                        node.put(field.toString(), udtValue.getFloat(field));
+                        break;
+                    case ProtocolConstants.DataType.BOOLEAN:
+                        node.put(field.toString(), udtValue.getBoolean(field));
+                        break;
+                    case ProtocolConstants.DataType.TIMESTAMP:
+                        node.put(field.toString(), udtValue.getInstant(field).toEpochMilli());
+                        break;
+                    case ProtocolConstants.DataType.DATE:
+                        node.put(field.toString(), (int) udtValue.getLocalDate(field).toEpochDay());
+                        break;
+                    case ProtocolConstants.DataType.TIME:
+                        node.put(field.toString(), (udtValue.getLocalTime(field).toNanoOfDay() / 1000));
+                        break;
+                    case ProtocolConstants.DataType.BLOB:
+                        node.put(field.toString(), udtValue.getByteBuffer(field).array());
+                        break;
+                    case ProtocolConstants.DataType.UDT:
+                        node.set(field.toString(), buildUDTValue(udtValue.getUdtValue(field)));
+                        break;
+                    case ProtocolConstants.DataType.DURATION:
+                        node.set(field.toString(), cqlDurationToJsonNode(udtValue.getCqlDuration(field)));
+                        break;
+                    case ProtocolConstants.DataType.DECIMAL:
+                        node.put(field.toString(), udtValue.getBigDecimal(field));
+                        break;
+                    case ProtocolConstants.DataType.VARINT:
+                        node.put(field.toString(), udtValue.getBigInteger(field));
+                        break;
+                    case ProtocolConstants.DataType.LIST: {
+                        ListType listType = (ListType) udtValue.getType(field);
+                        List listValue = udtValue.getList(field, CodecRegistry.DEFAULT.codecFor(listType.getElementType()).getJavaType().getRawType());
+                        String path = typeName + "." + field.toString();
+                        org.apache.avro.Schema elementSchema = subSchemas.get(path);
+                        log.debug("path={} elementSchema={} listType={} listValue={}", path, elementSchema, listType, listValue);
+                        node.set(field.toString(), createArrayNode(elementSchema, listValue));
+                    }
+                    break;
+                    case ProtocolConstants.DataType.SET: {
+                        SetType setType = (SetType) udtValue.getType(field);
+                        Set setValue = udtValue.getSet(field, CodecRegistry.DEFAULT.codecFor(setType.getElementType()).getJavaType().getRawType());
+                        String path = typeName + "." + field.toString();
+                        org.apache.avro.Schema elementSchema = subSchemas.get(path);
+                        log.debug("path={} elementSchema={} setType={} setValue={}", path, elementSchema, setType, setValue);
+                        node.set(field.toString(), createArrayNode(elementSchema, setValue));
+                    }
+                    break;
+                    case ProtocolConstants.DataType.MAP: {
+                        MapType mapType = (MapType) udtValue.getType(field);
+                        Map<String, Object> mapValue = udtValue.getMap(field,
+                                        CodecRegistry.DEFAULT.codecFor(mapType.getKeyType()).getJavaType().getRawType(),
+                                        CodecRegistry.DEFAULT.codecFor(mapType.getValueType()).getJavaType().getRawType())
+                                .entrySet().stream().collect(Collectors.toMap(e -> stringify(mapType.getKeyType(), e.getKey()), Map.Entry::getValue));
+                        String path = typeName + "." + field.toString();
+                        org.apache.avro.Schema valueSchema = subSchemas.get(path);
+                        log.debug("path={} valueSchema={} mapType={} mapValue={}", path, valueSchema, mapType, mapValue);
+                        node.set(field.toString(), mapper.valueToTree(mapValue));
+                    }
+                    break;
+                    default:
+                        log.debug("Ignoring unsupported type field name={} type={}", field, dataType.asCql(false, true));
+                }
+            }
+        }
+        return node;
+    }
+
+    JsonNode createArrayNode(org.apache.avro.Schema schema, Collection collection) {
+        ArrayNode node = JsonNodeFactory.instance.arrayNode(collection.size());
+        for(Object element : collection) {
+            if (element instanceof UdtValue) {
+                UdtValue udtValue = (UdtValue) element;
+                node.add(buildUDTValue(udtValue));
+            } else if (element instanceof Set) {
+                node.add(createArrayNode(schema.getElementType(), (Collection)element));
+            } else if (element instanceof List) {
+                node.add(createArrayNode(schema.getElementType(), (Collection)element));
+            } else {
+                JsonNode fieldValue = toJson(schema.getElementType(), element);
+                node.add(fieldValue);
+            }
+        }
+
+        return node;
+    }
+
+    public static byte[] serializeJsonNode(JsonNode node) {
+        try {
+            return mapper.writeValueAsBytes(node);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public byte[] fromConnectData(GenericRecord genericRecord) {
+        if (genericRecord == null) {
+            return null;
+        }
+        ObjectNode objectNode = jsonNodeFactory.objectNode();
+        for (org.apache.avro.Schema.Field field : genericRecord.getSchema().getFields()) {
+            objectNode.set(field.name(), toJson(field.schema(), genericRecord.get(field.name())));
+        }
+        return serializeJsonNode(objectNode);
+    }
+
+    private static Map<String, LogicalTypeConverter<?>> logicalTypeConverters = new HashMap<>();
+
+    private static JsonNode cqlDurationToJsonNode(CqlDuration cqlDuration) {
+        ObjectNode object = jsonNodeFactory.objectNode();
+        object.put(CqlLogicalTypes.CQL_DURATION_MONTHS, cqlDuration.getMonths());
+        object.put(CqlLogicalTypes.CQL_DURATION_DAYS, cqlDuration.getDays());
+        object.put(CqlLogicalTypes.CQL_DURATION_NANOSECONDS, cqlDuration.getNanoseconds());
+        return object;
+    }
+
+    private static JsonNode bigDecimalToJsonNode(BigDecimal bigDecimal) {
+        ObjectNode decimalNode = jsonNodeFactory.objectNode();
+        decimalNode.put(CqlLogicalTypes.CQL_DECIMAL_BIGINT, bigDecimal.unscaledValue().toByteArray())
+                .put(CqlLogicalTypes.CQL_DECIMAL_SCALE, bigDecimal.scale());
+
+        return decimalNode;
+    }
+    public static JsonNode toJson(org.apache.avro.Schema schema, Object value) {
+        // schema.getLogicalType() always returns null although the name would be populated with the logical type
+        // TODO: Use logical type instead of name
+        if (schema.getName() != null && logicalTypeConverters.containsKey(schema.getName())) {
+            return logicalTypeConverters.get(schema.getName()).toJson(value);
+        }
+
+        if (value == null) {
+            return jsonNodeFactory.nullNode();
+        }
+        switch(schema.getType()) {
+            case NULL: // this should not happen
+                return jsonNodeFactory.nullNode();
+            case INT:
+                return jsonNodeFactory.numberNode((Integer) value);
+            case LONG:
+                return jsonNodeFactory.numberNode((Long) value);
+            case DOUBLE:
+                return jsonNodeFactory.numberNode((Double) value);
+            case FLOAT:
+                return jsonNodeFactory.numberNode((Float) value);
+            case BOOLEAN:
+                return jsonNodeFactory.booleanNode((Boolean) value);
+            case BYTES:
+                return jsonNodeFactory.binaryNode(((ByteBuffer) value).array());
+            case FIXED:
+                return jsonNodeFactory.binaryNode(((GenericFixed) value).bytes());
+            case ENUM: // GenericEnumSymbol
+            case STRING:
+                return jsonNodeFactory.textNode(value.toString()); // can be a String or org.apache.avro.util.Utf8
+            case ARRAY:
+                org.apache.avro.Schema elementSchema = schema.getElementType();
+                ArrayNode arrayNode = jsonNodeFactory.arrayNode();
+                Object[] iterable;
+                if (value instanceof GenericData.Array) {
+                    iterable = ((GenericData.Array) value).toArray();
+                } else {
+                    iterable = (Object[]) value;
+                }
+                for (Object elem : iterable) {
+                    JsonNode fieldValue = toJson(elementSchema, elem);
+                    arrayNode.add(fieldValue);
+                }
+                return arrayNode;
+            case MAP:
+                @SuppressWarnings("unchecked") Map<Object, Object> map = (Map<Object, Object>) value;
+                ObjectNode objectNode = jsonNodeFactory.objectNode();
+                for (Map.Entry<Object, Object> entry : map.entrySet()) {
+                    JsonNode jsonNode = toJson(schema.getValueType(), entry.getValue());
+                    // can be a String or org.apache.avro.util.Utf8
+                    final String entryKey = entry.getKey() == null ? null : entry.getKey().toString();
+                    objectNode.set(entryKey, jsonNode);
+                }
+                return objectNode;
+            case RECORD:
+                return toJson((GenericRecord) value);
+            case UNION:
+                for (org.apache.avro.Schema s : schema.getTypes()) {
+                    if (s.getType() == org.apache.avro.Schema.Type.NULL) {
+                        continue;
+                    }
+                    return toJson(s, value);
+                }
+                // this case should not happen
+                return jsonNodeFactory.textNode(value.toString());
+            default:
+                throw new UnsupportedOperationException("Unknown AVRO schema type=" + schema.getType());
+        }
+    }
+
+    public static JsonNode toJson(GenericRecord genericRecord) {
+        if (genericRecord == null) {
+            return null;
+        }
+        ObjectNode objectNode = jsonNodeFactory.objectNode();
+        for (org.apache.avro.Schema.Field field : genericRecord.getSchema().getFields()) {
+            objectNode.set(field.name(), toJson(field.schema(), genericRecord.get(field.name())));
+        }
+        return objectNode;
+    }
+
+
+    public boolean isSupportedCqlType(DataType dataType) {
+        switch (dataType.getProtocolCode()) {
+            case ProtocolConstants.DataType.ASCII:
+            case ProtocolConstants.DataType.VARCHAR:
+            case ProtocolConstants.DataType.BOOLEAN:
+            case ProtocolConstants.DataType.BLOB:
+            case ProtocolConstants.DataType.DATE:
+            case ProtocolConstants.DataType.TIME:
+            case ProtocolConstants.DataType.TIMESTAMP:
+            case ProtocolConstants.DataType.UUID:
+            case ProtocolConstants.DataType.TIMEUUID:
+            case ProtocolConstants.DataType.TINYINT:
+            case ProtocolConstants.DataType.SMALLINT:
+            case ProtocolConstants.DataType.INT:
+            case ProtocolConstants.DataType.BIGINT:
+            case ProtocolConstants.DataType.DOUBLE:
+            case ProtocolConstants.DataType.FLOAT:
+            case ProtocolConstants.DataType.INET:
+            case ProtocolConstants.DataType.UDT:
+            case ProtocolConstants.DataType.VARINT:
+            case ProtocolConstants.DataType.DECIMAL:
+            case ProtocolConstants.DataType.DURATION:
+            case ProtocolConstants.DataType.LIST:
+            case ProtocolConstants.DataType.SET:
+            case ProtocolConstants.DataType.MAP:
+                return true;
+        }
+        return false;
+    }
+
+    abstract static class LogicalTypeConverter<T> {
+        final Conversion<T> conversion;
+
+        public LogicalTypeConverter(Conversion<T> conversion) {
+            this.conversion = conversion;
+        }
+
+        abstract JsonNode toJson(Object value);
+    }
+
+    static {
+        logicalTypeConverters.put(CqlLogicalTypes.CQL_DECIMAL, new NativeJsonConverter.LogicalTypeConverter<BigDecimal>(
+                new Conversions.DecimalConversion()) {
+
+            /**
+             * @return a json node representing a struct: {"bigint":"<base64 encoded bytes>", "scale":"<int scale of the big decimal>"}
+             */
+            @Override
+            JsonNode toJson(Object value) {
+                Conversion<BigDecimal> conversion = SpecificData.get().getConversionByClass(BigDecimal.class);
+                value =  conversion.fromRecord( (IndexedRecord) value, CqlLogicalTypes.decimalType, CqlLogicalTypes.CQL_DECIMAL_LOGICAL_TYPE);
+
+                if (!(value instanceof BigDecimal)) {
+                    throw new IllegalArgumentException("Invalid type for Decimal, expected BigDecimal but was "
+                            + value.getClass());
+                }
+
+                return bigDecimalToJsonNode((BigDecimal) value);
+            }
+        });
+        logicalTypeConverters.put(CqlLogicalTypes.CQL_DURATION, new NativeJsonConverter.LogicalTypeConverter<BigDecimal>(
+                new Conversions.DecimalConversion()) {
+
+            /**
+             * @return a json node representing a duration: {"month":"<int encoded months>", "days":"<int encoded days>", "nanoseconds":"<long encoded nanos>"}
+             */
+            @Override
+            JsonNode toJson(Object value) {
+                Conversion<CqlDuration> conversion = SpecificData.get().getConversionByClass(CqlDuration.class);
+                value =  conversion.fromRecord( (IndexedRecord) value, CqlLogicalTypes.durationType, CqlLogicalTypes.CQL_DECIMAL_LOGICAL_TYPE);
+
+                if (!(value instanceof CqlDuration)) {
+                    throw new IllegalArgumentException("Invalid type for Duration, expected CqlDuration but was "
+                            + value.getClass());
+                }
+
+                return cqlDurationToJsonNode((CqlDuration) value);
+            }
+        });
+    }
+}

--- a/connector/src/main/java/com/datastax/oss/pulsar/source/converters/NativeJsonConverter.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/converters/NativeJsonConverter.java
@@ -119,7 +119,7 @@ public class NativeJsonConverter extends AbstractNativeConverter<byte[]> {
                 String path = getSubSchemaPath(record, identifier);
                 org.apache.avro.Schema listSchema = subSchemas.get(path);
                 List listValue = record.getList(identifier, CodecRegistry.DEFAULT.codecFor(listType.getElementType()).getJavaType().getRawType());
-                log.info("field={} listSchema={} listValue={}", identifier, listSchema, listValue);
+                log.debug("field={} listSchema={} listValue={}", identifier, listSchema, listValue);
                 return createArrayNode(listSchema, listValue);
             }
             case ProtocolConstants.DataType.SET: {
@@ -244,7 +244,7 @@ public class NativeJsonConverter extends AbstractNativeConverter<byte[]> {
     }
     public static JsonNode toJson(org.apache.avro.Schema schema, Object value) {
         // schema.getLogicalType() always returns null although the name would be populated with the logical type
-        // TODO: Use logical type instead of name
+        // TODO: Use logical type instead of name https://github.com/datastax/cdc-apache-cassandra/issues/85
         if (schema.getName() != null && logicalTypeConverters.containsKey(schema.getName())) {
             return logicalTypeConverters.get(schema.getName()).toJson(value);
         }

--- a/connector/src/test/java/com/datastax/oss/cdc/CassandraSourceConnectorConfigTest.java
+++ b/connector/src/test/java/com/datastax/oss/cdc/CassandraSourceConnectorConfigTest.java
@@ -23,11 +23,13 @@ import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
 import com.datastax.oss.dsbulk.tests.assertions.TestAssertions;
 import com.datastax.oss.dsbulk.tests.logging.LogInterceptingExtension;
 import com.datastax.oss.dsbulk.tests.logging.LogInterceptor;
+import org.apache.kafka.common.protocol.types.Field;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -597,6 +599,35 @@ class CassandraSourceConnectorConfigTest {
         for (Map.Entry<String, String> entry : expectedDriverSettings.entrySet()) {
             assertThat(CassandraSourceConnectorConfig.getJavaDriverSettings()).contains(entry);
         }
+    }
+
+    @Test
+    void should_reject_invalid_output_format() {
+        Map<String, String> props =
+                ImmutableMap.<String, String>builder()
+                        .putAll(requiredSettings())
+                        .put(OUTPUT_FORMAT, "invalid")
+                        .build();
+
+        assertThatThrownBy(() -> new CassandraSourceConnectorConfig(props))
+                .isInstanceOf(ConfigException.class)
+                .hasMessageContaining("String must be one of: key-value-avro, key-value-json, json");    }
+
+    @ParameterizedTest
+    @ValueSource( strings = {"key-value-avro", "key-value-json", "json"})
+    void should_accept_valid_output_format(String format) {
+        // given
+        Map<String, String> props =
+                ImmutableMap.<String, String>builder()
+                        .putAll(requiredSettings())
+                        .put(OUTPUT_FORMAT, format)
+                        .build();
+
+        // when
+        CassandraSourceConnectorConfig config = new CassandraSourceConnectorConfig(props);
+
+        // then
+        assertThat(config.getOutputFormat()).isEqualTo(format);
     }
 
     private static Stream<? extends Arguments> sourceProvider() {

--- a/connector/src/test/java/com/datastax/oss/cdc/CassandraSourceConnectorConfigTest.java
+++ b/connector/src/test/java/com/datastax/oss/cdc/CassandraSourceConnectorConfigTest.java
@@ -614,20 +614,20 @@ class CassandraSourceConnectorConfigTest {
                 .hasMessageContaining("String must be one of: key-value-avro, key-value-json, json");    }
 
     @ParameterizedTest
-    @ValueSource( strings = {"key-value-avro", "key-value-json", "json"})
-    void should_accept_valid_output_format(String format) {
+    @MethodSource( "outputFormatProvider")
+    void should_accept_valid_output_format(String inputFormat, OutputFormat expectedFormat) {
         // given
         Map<String, String> props =
                 ImmutableMap.<String, String>builder()
                         .putAll(requiredSettings())
-                        .put(OUTPUT_FORMAT, format)
+                        .put(OUTPUT_FORMAT, inputFormat)
                         .build();
 
         // when
         CassandraSourceConnectorConfig config = new CassandraSourceConnectorConfig(props);
 
         // then
-        assertThat(config.getOutputFormat()).isEqualTo(format);
+        assertThat(config.getOutputFormat()).isEqualTo(expectedFormat);
     }
 
     private static Stream<? extends Arguments> sourceProvider() {
@@ -734,6 +734,13 @@ class CassandraSourceConnectorConfigTest {
                         ImmutableMap.of(SECURE_CONNECT_BUNDLE_DRIVER_SETTING, "path"),
                         SECURE_CONNECT_BUNDLE_DRIVER_SETTING,
                         "path"));
+    }
+
+    private static Stream<? extends Arguments> outputFormatProvider() {
+        return Stream.of(
+                Arguments.of("key-value-avro", OutputFormat.KEY_VALUE_AVRO),
+                Arguments.of("key-value-json", OutputFormat.KEY_VALUE_JSON),
+                Arguments.of("json", OutputFormat.JSON));
     }
 
     @ParameterizedTest

--- a/connector/src/test/java/com/datastax/oss/pulsar/source/AvroKeyValueCassandraSourceTests.java
+++ b/connector/src/test/java/com/datastax/oss/pulsar/source/AvroKeyValueCassandraSourceTests.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.source;
+
+import org.apache.pulsar.common.schema.SchemaType;
+
+public class AvroKeyValueCassandraSourceTests extends PulsarCassandraSourceTests {
+
+    public AvroKeyValueCassandraSourceTests() {
+        super("key-value-avro", SchemaType.KEY_VALUE);
+    }
+}

--- a/connector/src/test/java/com/datastax/oss/pulsar/source/JsonKeyValueCassandraSourceTests.java
+++ b/connector/src/test/java/com/datastax/oss/pulsar/source/JsonKeyValueCassandraSourceTests.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.source;
+
+import org.apache.pulsar.common.schema.SchemaType;
+
+public class JsonKeyValueCassandraSourceTests extends PulsarCassandraSourceTests{
+    public JsonKeyValueCassandraSourceTests() {
+        super("key-value-json", SchemaType.KEY_VALUE);
+    }
+}

--- a/connector/src/test/java/com/datastax/oss/pulsar/source/JsonOnlyCassandraSourceTests.java
+++ b/connector/src/test/java/com/datastax/oss/pulsar/source/JsonOnlyCassandraSourceTests.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.source;
+
+import org.apache.pulsar.common.schema.SchemaType;
+
+public class JsonOnlyCassandraSourceTests  extends PulsarCassandraSourceTests {
+    public JsonOnlyCassandraSourceTests() {
+        super("json", SchemaType.JSON);
+    }
+}

--- a/testcontainers/src/main/java/com/datastax/oss/cdc/DataSpec.java
+++ b/testcontainers/src/main/java/com/datastax/oss/cdc/DataSpec.java
@@ -58,6 +58,18 @@ public class DataSpec
         this.primaryKey = primaryKey;
         this.clusteringKey = clusteringKey;
     }
+    public Object jsonValue() {
+        if (avroValue instanceof ByteBuffer) {
+            // jackson encodes byte[] as Base64 string
+            byte[] bytes = ((ByteBuffer) avroValue).array();
+            return ((ByteBuffer) avroValue).array();
+        } else if (avroValue instanceof Float) {
+            // jackson encodes both doubles and floats exactly the same, it is safe to cast to a higher precision
+            return ((Float) avroValue).doubleValue();
+        }
+
+        return avroValue;
+    }
 
     public static final List<DataSpec> dataSpecs = new Vector<>();
     public static Map<String, DataSpec> dataSpecMap;
@@ -80,7 +92,7 @@ public class DataSpec
         dataSpecs.add(new DataSpec("tinyint", (byte) 0x01, (int) 0x01)); // Avro only support integer
         dataSpecs.add(new DataSpec("smallint", (short) 1, (int) 1)); // Avro only support integer
         dataSpecs.add(new DataSpec("int", 1));
-        dataSpecs.add(new DataSpec("bigint", 1L));
+        dataSpecs.add(new DataSpec("bigint", Long.MAX_VALUE)); // Jackson will decide at runtime to deserialize a number as int or long, using max long value to force it to use long.
         dataSpecs.add(new DataSpec("varint", new BigInteger("314"), new CqlLogicalTypes.CqlVarintConversion().toBytes(new BigInteger("314"), CqlLogicalTypes.varintType, CqlLogicalTypes.CQL_VARINT_LOGICAL_TYPE)));
         dataSpecs.add(new DataSpec("decimal", new BigDecimal(314.16), new BigDecimal(314.16)));
         dataSpecs.add(new DataSpec("double", 1.0D));

--- a/testcontainers/src/main/java/com/datastax/oss/cdc/DataSpec.java
+++ b/testcontainers/src/main/java/com/datastax/oss/cdc/DataSpec.java
@@ -61,7 +61,6 @@ public class DataSpec
     public Object jsonValue() {
         if (avroValue instanceof ByteBuffer) {
             // jackson encodes byte[] as Base64 string
-            byte[] bytes = ((ByteBuffer) avroValue).array();
             return ((ByteBuffer) avroValue).array();
         } else if (avroValue instanceof Float) {
             // jackson encodes both doubles and floats exactly the same, it is safe to cast to a higher precision


### PR DESCRIPTION
This PR introduces two new format for C* source ([issue](https://github.com/datastax/cdc-apache-cassandra/issues/74)):
* kev-value-json: Similar to the existing AVRO option, the schema of the Pulsar record will be KEY_SCHEMA (key & value are SEPARATED JSON)  
* json: This option format the record as JSON only, so all fields in the payload (whether key or value fields) are top level fields in the value:
```
{
  "key1" : "...",
  "key2": "...".
   ...,
   "field1" : "...",
   "field2" : "...".
   ...
}
```

the record will have the key part encoded as will as an escaped json string.

To handle delete mutations for JSON only format, the data topic will receive an empty JSON payload '{}' - pulsar doesn't allow null payloads.