### PR TITLE
[ci] Add complete build on CI to ensure all checks pass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build project
-          env:
-            DSE_REPO_USERNAME: ${{ secrets.DSE_REPO_USERNAME }}
-            DSE_REPO_PASSWORD: ${{ secrets.DSE_REPO_PASSWORD }}
-          run: |
-            ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
-            build -x test
+        env:
+          DSE_REPO_USERNAME: ${{ secrets.DSE_REPO_USERNAME }}
+          DSE_REPO_PASSWORD: ${{ secrets.DSE_REPO_PASSWORD }}
+        run: |
+          ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
+          build -x test
 
   test:
     needs: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    name: Build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build project
+          env:
+            DSE_REPO_USERNAME: ${{ secrets.DSE_REPO_USERNAME }}
+            DSE_REPO_PASSWORD: ${{ secrets.DSE_REPO_PASSWORD }}
+          run: |
+            ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
+            build -x test
+
+  test:
+    needs: build
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Currently the master branch doesn't compile due to license errors.
```
> License violations were found: /home/jenkins/workspace/Connectors/CDC_Push_Snapshot/connector/src/main/java/com/datastax/oss/pulsar/source/converters/NativeJsonConverter.java,/home/jenkins/workspace/Connectors/CDC_Push_Snapshot/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractNativeConverter.java}
```

The CI doesn't intercept the error since all the gradle command are just `test` and the license check doesn't depend on that phase.
