### PR TITLE
Upgrade jackson to 2.12.7.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ messagingConnectorsCommonsVersion=1.0.14
 slf4jVersion=1.7.30
 # pulsar connector
 logbackVersion=1.2.9
-jacksonDatabindVersion=2.12.6.1
+jacksonDatabindVersion=2.12.7.1
 jnrVersion=3.1.15
 nettyVersion=4.1.72.Final
 nettyTcNativeVersion=2.0.46.Final


### PR DESCRIPTION
### Motivation

`jackson-databind`  2.12.6.1 is vulnerable to [CVE-2022-42003](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42003)

### Modifications

* Upgrade to 2.12.7.1

there's no strong reason to bump to 2.13.x so it's more conservative to remain on 2.12.x

