### PR TITLE
Update artifactory extraRepoUrl to use datastax-releases-local

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ version=2.2.2
 group=com.datastax.oss.cdc
 
 # repositories
-extraRepoUrl=https://repo.aws.dsinternal.org/artifactory/datastax-snapshots-local
+extraRepoUrl=https://repo.aws.dsinternal.org/artifactory/datastax-releases-local
 snapshotsRepoUrl=https://repo.aws.dsinternal.org/artifactory/datastax-snapshots-local
 releasesRepoUrl=https://repo.datastax.com/artifactory/datastax-public-releases-local
 


### PR DESCRIPTION
Updating artifactory URL - using this PR mainly to verify CI will work with the new URLs. Previous PRs checks failed with:
```
* What went wrong:
Execution failed for task ':agent-dse4:compileJava'.
> Could not resolve all files for configuration ':agent-dse4:compileClasspath'.

   > Could not resolve com.datastax.dse:dse-db:6.8.23.
     Required by:
         project :agent-dse4
      > Could not resolve com.datastax.dse:dse-db:6.8.23.
         > Could not get resource 'https://repo.datastax.com/artifactory/dse/com/datastax/dse/dse-db/6.8.23/dse-db-6.8.23.pom'.
            > Could not GET 'https://repo.datastax.com/artifactory/dse/com/datastax/dse/dse-db/6.8.23/dse-db-6.8.23.pom'. Received status code 401 from server: Unauthorized
      > Could not resolve com.datastax.dse:dse-db:6.8.23.
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
         > Could not get resource 'https://repo.aws.dsinternal.org/artifactory/datastax-snapshots-local/com/datastax/dse/dse-db/6.8.23/dse-db-6.8.23.pom'.
            > Could not GET 'https://repo.aws.dsinternal.org/artifactory/datastax-snapshots-local/com/datastax/dse/dse-db/6.8.23/dse-db-6.8.23.pom'.
               > repo.aws.dsinternal.org: Name or service not known
```