### PR TITLE
Use SchemaInfo API to build SchemaInfo objects

### DIFF
--- a/commons/src/main/java/com/datastax/oss/cdc/NativeSchemaWrapper.java
+++ b/commons/src/main/java/com/datastax/oss/cdc/NativeSchemaWrapper.java
@@ -17,7 +17,6 @@ package com.datastax.oss.cdc;
 
 import org.apache.avro.Schema;
 import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
-import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
@@ -35,7 +34,7 @@ public class NativeSchemaWrapper implements org.apache.pulsar.client.api.Schema<
     public NativeSchemaWrapper(Schema nativeSchema, SchemaType pulsarSchemaType) {
         this.nativeSchema = nativeSchema;
         this.pulsarSchemaType = pulsarSchemaType;
-        this.pulsarSchemaInfo = SchemaInfoImpl.builder()
+        this.pulsarSchemaInfo = SchemaInfo.builder()
                 .schema(nativeSchema.toString(false).getBytes(StandardCharsets.UTF_8))
                 .properties(new HashMap<>())
                 .type(pulsarSchemaType)


### PR DESCRIPTION
Refrain from using the `SchemaInfoImpl` import to build schema info object. While testing with LS, the following error would manifest specifically when using `json` only output format:
```
...
Caused by: java.lang.ClassCastException: class org.apache.pulsar.client.impl.schema.SchemaInfoImpl cannot be cast to cl │
│     at org.apache.pulsar.common.protocol.schema.SchemaHash.of(SchemaHash.java:52) ~[com.datastax.oss-pulsar-common-2.10 │
``` 

I tested this patch by building a nar file locally and use it with k8s hosted LS image. 