### PR TITLE
update-ui-and-content-source-url

### DIFF
--- a/docs/playbooks/site-local-cdcCassandra.yaml
+++ b/docs/playbooks/site-local-cdcCassandra.yaml
@@ -1,17 +1,16 @@
 site:
   title: DataStax CDC for Apache Cassandra documentation
   url: /docs/cdc-apache-cassandra
-  start_page: cdc-apache-cassandra::index.adoc
 
 content:
   sources:
-  - url: ./..
+  - url: ./../..
     branches: HEAD
     start-path: docs/docs-src/core
 
 ui:
   bundle:
-    url: https://github.com/riptano/antora-ui-pulsar/raw/main/releases/download/v0.2/ui-bundle.zip
+    url: https://github.com/riptano/antora-ui-docs/releases/latest/download/ui-bundle.zip
     snapshot: true
   supplemental_files: ./supplemental-ui
   output_dir: assets

--- a/docs/playbooks/site-publish-cdcCassandra.yaml
+++ b/docs/playbooks/site-publish-cdcCassandra.yaml
@@ -1,7 +1,6 @@
 site:
   title: DataStax CDC for Apache Cassandra documentation
   url: https://docs.datastax.com/en/cdc-for-cassandra
-  start_page: cdc-apache-cassandra::index.adoc
 
 output:
   dir: '~/work/cdc-apache-cassandra/docs/build/site'
@@ -15,7 +14,7 @@ content:
 
 ui:
   bundle:
-    url: https://github.com/riptano/antora-ui-pulsar/raw/main/releases/download/v0.2/ui-bundle.zip
+    url: https://github.com/riptano/antora-ui-docs/releases/latest/download/ui-bundle.zip
     snapshot: true
   supplemental_files: '~/work/cdc-apache-cassandra/docs/playbooks/supplemental-ui'
   output_dir: assets


### PR DESCRIPTION
* Update UI bundle to
url: https://github.com/riptano/antora-ui-docs/releases/latest/download/ui-bundle.zip
* No build errors locally. There are more changes to make in upcoming cleanup. (https://github.com/datastax/cdc-apache-cassandra/pull/105)
Coppi build: https://coppi.aws.dsinternal.org/en/docs-update-ui-bundle/docs/2.2.2/index.html