### PR TITLE
Implement cdc backfill skeleton

### DIFF
--- a/agent-dse4/src/main/java/com/datastax/oss/cdc/agent/PulsarMutationSender.java
+++ b/agent-dse4/src/main/java/com/datastax/oss/cdc/agent/PulsarMutationSender.java
@@ -84,6 +84,10 @@ public class PulsarMutationSender extends AbstractPulsarMutationSender<TableMeta
         super(config, DatabaseDescriptor.getPartitionerName().equals(Murmur3Partitioner.class.getName()));
     }
 
+    public PulsarMutationSender(AgentConfig config, boolean useMurmur3Partitioner) {
+        super(config, useMurmur3Partitioner);
+    }
+
     @Override
     public void incSkippedMutations() {
         CdcMetrics.skippedMutations.inc();

--- a/cdc-backfill-client/README.md
+++ b/cdc-backfill-client/README.md
@@ -1,0 +1,6 @@
+# CDC Backfill Client
+
+A tool that reads rows from an existing Cassandra table and send their primary keys to the event topic. This will
+trigger the Cassandra Source Connector (CSC) to populate the date topics with historical rows (i.e. existed 
+before enabling cdc on the table). Please note the CSC only guarantees sending the latest state of rows and not
+necessarily their intermediary states. 

--- a/cdc-backfill-client/build.gradle
+++ b/cdc-backfill-client/build.gradle
@@ -1,0 +1,56 @@
+plugins {
+    id 'com.github.johnrengelman.shadow'
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': "$mainClassName"
+    }
+}
+
+shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    manifest {
+        attributes(
+                'Main-Class': "$mainClassName"
+        )
+    }
+
+    // Required to merge the 'dsbulk-reference.conf' otherwise the runtime will fail with:
+    // No configuration setting found for key 'dsbulk.metaSettings'
+    transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer) {
+        resource = 'dsbulk-reference.conf'
+    }
+
+    zip64=true
+}
+
+jar.enabled = true
+assemble.dependsOn(shadowJar)
+
+dependencies {
+    implementation project(':agent-dse4')
+    implementation project(':agent')
+
+    implementation "com.datastax.oss:dsbulk-config:${dsbulkVersion}"
+    implementation "com.datastax.oss:dsbulk-runner:${dsbulkVersion}"
+    implementation "com.datastax.oss:dsbulk-workflow-unload:${dsbulkVersion}"
+    implementation "com.datastax.oss:dsbulk-connectors-csv:${dsbulkVersion}"
+    implementation "com.datastax.oss:dsbulk-executor-reactor:${dsbulkVersion}"
+    implementation "com.datastax.oss:dsbulk-batcher-reactor:${dsbulkVersion}"
+    implementation "com.google.guava:guava:${guavaVersion}"
+
+    implementation "info.picocli:picocli:4.6.3"
+    implementation "org.slf4j:slf4j-api:1.7.36"
+    implementation "ch.qos.logback:logback-classic:1.2.11"
+    implementation "org.apache.cassandra:cassandra-all:${cassandra4Version}"
+    implementation "com.datastax.dse:dse-db:${dse4Version}"
+    implementation "${pulsarGroup}:pulsar-client:${pulsarVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.1"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.1"
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/cdc-backfill-client/gradle.properties
+++ b/cdc-backfill-client/gradle.properties
@@ -1,0 +1,2 @@
+artifact=cdc-backfill-client
+mainClassName=com.datastax.oss.cdc.backfill.BackfillCLI

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/BackFillSettings.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/BackFillSettings.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+public class BackFillSettings {
+
+    @CommandLine.Option(
+            names = {"-h", "--help"},
+            usageHelp = true,
+            description = "Displays this help message.")
+    boolean usageHelpRequested;
+
+    @CommandLine.Option(
+            names = {"-d", "--data-dir"},
+            paramLabel = "PATH",
+            description =
+                    "The directory where data will be exported to and imported from."
+                            + "The default is a 'data' subdirectory in the current working directory. "
+                            + "The data directory will be created if it does not exist. "
+                            + "Tables will be exported and imported in subdirectories of the data directory specified here; "
+                            + "there will be one subdirectory per keyspace inside the data directory, "
+                            + "then one subdirectory per table inside each keyspace directory.",
+            defaultValue = "data")
+    public Path dataDir = Paths.get("data");
+
+    @CommandLine.Option(
+            names = {"-k", "--keyspace"},
+            required = true,
+            description =
+                    "The name of the keyspace where the table to be exported exist")
+    public String keyspace;
+
+    @CommandLine.Option(
+            names = {"-t", "--table"},
+            required = true,
+            description =
+                    "The name of the table to export data from for cdc back filling")
+    public String table;
+
+
+    @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
+    public ExportSettings exportSettings = new ExportSettings();
+
+    @CommandLine.Option(
+            names = {"-c", "--dsbulk-cmd"},
+            paramLabel = "CMD",
+            description =
+                    "The external DSBulk command to use. Ignored if the embedded DSBulk is being used. "
+                            + "The default is simply 'dsbulk', assuming that the command is available through the "
+                            + "PATH variable contents.",
+            defaultValue = "dsbulk")
+    public String dsbulkCmd = "dsbulk";
+
+    @CommandLine.Option(
+            names = {"-l", "--dsbulk-log-dir"},
+            paramLabel = "PATH",
+            description =
+                    "The directory where DSBulk should store its logs. "
+                            + "The default is a 'logs' subdirectory in the current working directory. "
+                            + "This subdirectory will be created if it does not exist. "
+                            + "Each DSBulk operation will create a subdirectory inside the log directory specified here.",
+            defaultValue = "logs")
+    public Path dsbulkLogDir = Paths.get("logs");
+
+    @CommandLine.Option(
+            names = {"-w", "--dsbulk-working-dir"},
+            paramLabel = "PATH",
+            description =
+                    "The directory where DSBulk should be executed. "
+                            + "Ignored if the embedded DSBulk is being used. "
+                            + "If unspecified, it defaults to the current working directory.")
+    public Path dsbulkWorkingDir;
+
+    @CommandLine.Option(
+            names = "--max-concurrent-ops",
+            paramLabel = "NUM",
+            description =
+                    "The maximum number of concurrent operations (exports and imports) to carry. Default is 1. "
+                            + "Set this to higher values to allow exports and imports to occur concurrently; "
+                            + "e.g. with a value of 2, each table will be imported as soon as it is exported, "
+                            + "while the next table is being exported.",
+            defaultValue = "1")
+    public int maxConcurrentOps = 1;
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/BackfillCLI.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/BackfillCLI.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+
+import com.datastax.oss.cdc.backfill.util.LoggingUtils;
+import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(
+        name = "BackfillCLI",
+        description =
+                "A tool for read historical data from a Cassandra table and sending equivalent mutation records " +
+                        "to the events topic.",
+        versionProvider = VersionProvider.class,
+        sortOptions = false,
+        usageHelpWidth = 100)
+public class BackfillCLI {
+
+    @Option(
+            names = {"-h", "--help"},
+            usageHelp = true,
+            description = "Displays this help message.")
+    boolean usageHelpRequested;
+
+    @Option(
+            names = {"-v", "--version"},
+            versionHelp = true,
+            description = "Displays version info.")
+    boolean versionInfoRequested;
+
+    public static void main(String[] args) {
+        LoggingUtils.configureLogging(LoggingUtils.MIGRATOR_CONFIGURATION_FILE);
+        CommandLine commandLine = new CommandLine(new BackfillCLI());
+        int exitCode = commandLine.execute(args);
+        System.exit(exitCode);
+    }
+
+    @Command(
+            name = "backfill",
+            optionListHeading = "Available options:%n",
+            abbreviateSynopsis = true,
+            usageHelpWidth = 100)
+    private int backfill(
+            @ArgGroup(exclusive = false, multiplicity = "1") BackFillSettings settings) {
+        CassandraToPulsarMigrator migrator = new CassandraToPulsarMigrator(settings);
+        return migrator.migrate().exitCode();
+    }
+}
+

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/CassandraToPulsarMigrator.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/CassandraToPulsarMigrator.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+import com.datastax.oss.cdc.backfill.util.ConnectorUtils;
+import com.datastax.oss.cdc.backfill.util.ModelUtils;
+import com.datastax.oss.dsbulk.connectors.csv.CSVConnector;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class CassandraToPulsarMigrator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraToPulsarMigrator.class);
+
+    private static final Object POISON_PILL = new Object();
+
+    private final BackFillSettings settings;
+    private final BlockingQueue<TableExporter> exportQueue;
+    private final BlockingQueue<Object> importQueue;
+    private final ExecutorService pool;
+
+    private final CopyOnWriteArrayList<TableExportReport> successful =
+            new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<TableExportReport> failed = new CopyOnWriteArrayList<>();
+
+    private final TableExporter exporter;
+
+    private final PulsarImporter importer;
+
+    public CassandraToPulsarMigrator(BackFillSettings settings) {
+        this.settings = settings;
+        exportQueue = new LinkedBlockingQueue<>();
+        importQueue = new LinkedBlockingQueue<>();
+        pool = Executors.newFixedThreadPool(settings.maxConcurrentOps);
+        final ExportedTable table = ModelUtils.buildExportedTable(
+                settings.exportSettings.clusterInfo, settings.exportSettings.credentials, settings);
+        // export from C* table to disk
+        exporter = new TableExporter(table, settings);
+        CSVConnector connector = new CSVConnector();
+        Config connectorConfig =
+                ConnectorUtils.createConfig(
+                        "dsbulk.connector.csv",
+                        "url",
+                        exporter.tableDataDir,
+                        "recursive",
+                        true,
+                        "fileNamePattern",
+                        "\"**/output-*\"");
+        connector.configure(connectorConfig, true, true);
+
+        // import from disk to Pulsar topic
+        importer = new PulsarImporter(connector, table);
+    }
+
+    public ExitStatus migrate() {
+        try {
+            migrateTables();
+            exportQueue.clear();
+            importQueue.clear();
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        } finally {
+            pool.shutdownNow();
+            LOGGER.info(
+                    "Migration finished with {} successfully migrated tables, {} failed tables.",
+                    successful.size(),
+                    failed.size());
+            for (TableExportReport report : successful) {
+                LOGGER.info("Table {} migrated successfully.", report.getMigrator().getExportedTable());
+            }
+            for (TableExportReport report : failed) {
+                LOGGER.error(
+                        "Table {} could not be {}: operation {} exited with {}.",
+                        report.getMigrator().getExportedTable(),
+                        report.isExport() ? "exported" : "imported",
+                        report.getOperationId(),
+                        report.getStatus());
+            }
+        }
+        if (failed.isEmpty()) {
+            return ExitStatus.STATUS_OK;
+        }
+        if (successful.isEmpty()) {
+            return ExitStatus.STATUS_ABORTED_TOO_MANY_ERRORS;
+        }
+        return ExitStatus.STATUS_COMPLETED_WITH_ERRORS;
+    }
+
+    private void migrateTables() {
+        exportQueue.add(exporter);
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        futures.add(CompletableFuture.runAsync(this::exportTables, pool));
+        futures.add(CompletableFuture.runAsync(this::importTables, pool));
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0])).join();
+    }
+
+    private void exportTables() {
+        TableExporter migrator;
+        while ((migrator = exportQueue.poll()) != null) {
+            TableExportReport report;
+            try {
+                report = migrator.exportTable();
+            } catch (Exception e) {
+                LOGGER.error(
+                        "Table "
+                                + migrator.getExportedTable()
+                                + ": unexpected error when exporting data, aborting",
+                        e);
+                report =
+                        new TableExportReport(migrator, ExitStatus.STATUS_ABORTED_FATAL_ERROR, null, true);
+            }
+            if (report.getStatus() == ExitStatus.STATUS_OK) {
+                importQueue.add(migrator);
+            } else {
+                failed.add(report);
+            }
+        }
+        importQueue.add(POISON_PILL);
+    }
+
+    private void importTables() {
+        // Output useful logs
+        while (true) {
+            TableExporter migrator;
+            try {
+                Object o = importQueue.take();
+                if (o == POISON_PILL) {
+                    break;
+                }
+                migrator = (TableExporter) o;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            TableExportReport report;
+            try {
+                report = importer.importTable(migrator); // TODO: Decouple status reports between Exporter & Importer
+            } catch (Exception e) {
+                LOGGER.error(
+                        "Table "
+                                + migrator.getExportedTable()
+                                + ": unexpected error when importing data, aborting",
+                        e);
+                report =
+                        new TableExportReport(migrator, ExitStatus.STATUS_ABORTED_FATAL_ERROR, null, false);
+            }
+            if (report.getStatus() == ExitStatus.STATUS_OK) {
+                successful.add(report);
+            } else {
+                failed.add(report);
+            }
+        }
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ClusterInfo.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ClusterInfo.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.List;
+
+public interface ClusterInfo {
+
+    boolean isOrigin();
+
+    List<InetSocketAddress> getContactPoints();
+
+    Path getBundle();
+
+    String getProtocolVersion();
+
+    default boolean isAstra() {
+        return getBundle() != null;
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/Credentials.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/Credentials.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+public interface Credentials {
+
+    String getUsername();
+
+    char[] getPassword();
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ExitStatus.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ExitStatus.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+// copy of DSBulk ExitStatus
+public enum ExitStatus {
+    STATUS_OK(0),
+    STATUS_COMPLETED_WITH_ERRORS(1),
+    STATUS_ABORTED_TOO_MANY_ERRORS(2),
+    STATUS_ABORTED_FATAL_ERROR(3),
+    STATUS_INTERRUPTED(4),
+    STATUS_CRASHED(5),
+    ;
+
+    private final int exitCode;
+
+    ExitStatus(int exitCode) {
+        this.exitCode = exitCode;
+    }
+
+    public static ExitStatus forCode(int exitCode) {
+        switch (exitCode) {
+            case 0:
+                return ExitStatus.STATUS_OK;
+            case 1:
+                return ExitStatus.STATUS_COMPLETED_WITH_ERRORS;
+            case 2:
+                return ExitStatus.STATUS_ABORTED_TOO_MANY_ERRORS;
+            case 3:
+                return ExitStatus.STATUS_ABORTED_FATAL_ERROR;
+            case 4:
+                return ExitStatus.STATUS_INTERRUPTED;
+            default:
+                return ExitStatus.STATUS_CRASHED;
+        }
+    }
+
+    public int exitCode() {
+        return exitCode;
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ExportSettings.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ExportSettings.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.cdc.backfill;
+
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+import com.datastax.oss.driver.shaded.guava.common.net.HostAndPort;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
+
+public class ExportSettings {
+
+    @ArgGroup(multiplicity = "1")
+    public ExportClusterInfo clusterInfo;
+
+    public static class ExportClusterInfo implements ClusterInfo {
+
+        @Option(
+                names = "--export-host",
+                paramLabel = "HOST[:PORT]",
+                description =
+                        "The host name or IP and, optionally, the port of a node from the origin cluster. "
+                                + "If the port is not specified, it will default to 9042. "
+                                + "This option can be specified multiple times. "
+                                + "Options --export-host and --export-bundle are mutually exclusive.",
+                converter = HostAndPortConverter.class,
+                required = true)
+        public List<HostAndPort> hostsAndPorts;
+
+        @Option(
+                names = "--export-bundle",
+                paramLabel = "PATH",
+                description =
+                        "The path to a secure connect bundle to connect to the origin cluster, "
+                                + "if that cluster is a DataStax Astra cluster. "
+                                + "Options --export-host and --export-bundle are mutually exclusive.",
+                required = true)
+        public Path bundle;
+
+        @Option(
+                names = "--export-protocol-version",
+                paramLabel = "VERSION",
+                description =
+                        "The protocol version to use to connect to the origin cluster, e.g. 'V4'. "
+                                + "If not specified, the driver will negotiate the highest version supported by both "
+                                + "the client and the server.")
+        public String protocolVersion;
+
+        @Override
+        public boolean isOrigin() {
+            return true;
+        }
+
+        @Override
+        public List<InetSocketAddress> getContactPoints() {
+            if (hostsAndPorts == null || hostsAndPorts.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return hostsAndPorts.stream()
+                    .map(
+                            hp ->
+                                    InetSocketAddress.createUnresolved(
+                                            hp.getHost(), hp.hasPort() ? hp.getPort() : 9042))
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public Path getBundle() {
+            return bundle;
+        }
+
+        @Override
+        public String getProtocolVersion() {
+            return protocolVersion;
+        }
+    }
+
+    @ArgGroup(exclusive = false)
+    public ExportCredentials credentials;
+
+    public static class ExportCredentials implements Credentials {
+
+        @Option(
+                names = "--export-username",
+                paramLabel = "STRING",
+                description =
+                        "The username to use to authenticate against the origin cluster. "
+                                + "Options --export-username and --export-password must be provided together, or not at all.",
+                required = true)
+        public String username;
+
+        @Option(
+                names = "--export-password",
+                paramLabel = "STRING",
+                description =
+                        "The password to use to authenticate against the origin cluster. "
+                                + "Options --export-username and --export-password must be provided together, or not at all. "
+                                + "Omit the parameter value to be prompted for the password interactively.",
+                required = true,
+                prompt = "Enter the password to use to authenticate against the origin cluster: ",
+                interactive = true)
+        public char[] password;
+
+        @Override
+        public String getUsername() {
+            return username;
+        }
+
+        @Override
+        public char[] getPassword() {
+            return password;
+        }
+    }
+
+    @Option(
+            names = "--export-consistency",
+            paramLabel = "CONSISTENCY",
+            description =
+                    "The consistency level to use when exporting data. The default is LOCAL_QUORUM.",
+            defaultValue = "LOCAL_QUORUM")
+    public DefaultConsistencyLevel consistencyLevel = DefaultConsistencyLevel.LOCAL_QUORUM;
+
+    @Option(
+            names = "--export-max-records",
+            paramLabel = "NUM",
+            description =
+                    "The maximum number of records to export for each table. Must be a positive number or -1. "
+                            + "The default is -1 (export the entire table).",
+            defaultValue = "-1")
+    public int maxRecords = -1;
+
+    @Option(
+            names = "--export-max-concurrent-files",
+            paramLabel = "NUM|AUTO",
+            description =
+                    "The maximum number of concurrent files to write to. "
+                            + "Must be a positive number or the special value AUTO. The default is AUTO.",
+            defaultValue = "AUTO")
+    public String maxConcurrentFiles = "AUTO";
+
+    @Option(
+            names = "--export-max-concurrent-queries",
+            paramLabel = "NUM|AUTO",
+            description =
+                    "The maximum number of concurrent queries to execute. "
+                            + "Must be a positive number or the special value AUTO. The default is AUTO.",
+            defaultValue = "AUTO")
+    public String maxConcurrentQueries = "AUTO";
+
+    @Option(
+            names = "--export-splits",
+            paramLabel = "NUM|NC",
+            description =
+                    "The maximum number of token range queries to generate. "
+                            + "Use the NC syntax to specify a multiple of the number of available cores, "
+                            + "e.g. 8C = 8 times the number of available cores. The default is 8C. "
+                            + "This is an advanced setting; you should rarely need to modify the default value.",
+            defaultValue = "8C")
+    public String splits = "8C";
+
+    @Option(
+            names = "--export-dsbulk-option",
+            paramLabel = "OPT=VALUE",
+            description =
+                    "An extra DSBulk option to use when exporting. "
+                            + "Any valid DSBulk option can be specified here, and it will passed as is to the DSBulk process. "
+                            + "DSBulk options, including driver options, must be passed as '--long.option.name=<value>'. "
+                            + "Short options are not supported. ")
+    public List<String> extraDsbulkOptions = new ArrayList<>();
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ExportedColumn.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ExportedColumn.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+
+public class ExportedColumn {
+
+    public final ColumnMetadata col;
+    public final boolean pk;
+    public final CqlIdentifier writetime;
+    public final CqlIdentifier ttl;
+
+    public ExportedColumn(
+            ColumnMetadata col, boolean pk, CqlIdentifier writetime, CqlIdentifier ttl) {
+        this.col = col;
+        this.pk = pk;
+        this.writetime = writetime;
+        this.ttl = ttl;
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ExportedTable.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/ExportedTable.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+import com.datastax.oss.cdc.backfill.util.TableUtils;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+
+import java.util.List;
+
+public class ExportedTable {
+
+    public final KeyspaceMetadata keyspace;
+    public final TableMetadata table;
+    public final List<ExportedColumn> columns;
+    public final String fullyQualifiedName;
+
+    public ExportedTable(
+            KeyspaceMetadata keyspace, TableMetadata table, List<ExportedColumn> columns) {
+        this.table = table;
+        this.keyspace = keyspace;
+        this.columns = columns;
+        fullyQualifiedName = TableUtils.getFullyQualifiedTableName(table);
+    }
+
+    @Override
+    public String toString() {
+        return fullyQualifiedName;
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/HostAndPortConverter.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/HostAndPortConverter.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+import com.datastax.oss.driver.shaded.guava.common.net.HostAndPort;
+import picocli.CommandLine.ITypeConverter;
+
+public class HostAndPortConverter implements ITypeConverter<HostAndPort> {
+
+    public HostAndPort convert(String value) {
+        return HostAndPort.fromString(value);
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/PulsarImporter.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/PulsarImporter.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+import com.clearspring.analytics.stream.membership.DataOutputBuffer;
+import com.datastax.oss.cdc.agent.AgentConfig;
+import com.datastax.oss.cdc.agent.Mutation;
+import com.datastax.oss.cdc.agent.PulsarMutationSender;
+import com.datastax.oss.dsbulk.connectors.api.Connector;
+import com.datastax.oss.dsbulk.connectors.api.DefaultIndexedField;
+import com.datastax.oss.dsbulk.connectors.api.Resource;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.schema.TableMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static com.datastax.oss.cdc.agent.AgentConfig.PULSAR_SERVICE_URL;
+
+public class PulsarImporter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableExporter.class);
+
+    final private Connector connector;
+    final private ExportedTable exportedTable;
+
+    public PulsarImporter(Connector connector, ExportedTable exportedTable) {
+        this.connector = connector;
+        this.exportedTable = exportedTable;
+    }
+
+    public TableExportReport importTable(TableExporter migrator) {
+        try {
+            connector.init();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to init connector!", e);
+        }
+        String operationId = "OperationID"; // TODO: Retrieve operation ID retrieveImportOperationId();
+        Map<String, Object> tenantInfo = new HashMap<>();
+        tenantInfo.put(PULSAR_SERVICE_URL, "pulsar://localhost:6650/");
+        //tenantInfo.put(PULSAR_AUTH_PLUGIN_CLASS_NAME, "MyAuthPlugin");
+        //tenantInfo.put(PULSAR_AUTH_PARAMS, "sdds");
+        //tenantInfo.put(SSL_ALLOW_INSECURE_CONNECTION, "true");
+        //tenantInfo.put(SSL_HOSTNAME_VERIFICATION_ENABLE, "true");
+        //tenantInfo.put(TLS_TRUST_CERTS_FILE_PATH, "/test.p12");
+
+        AgentConfig config = AgentConfig.create(AgentConfig.Platform.PULSAR, tenantInfo);
+        PulsarMutationSender sender = new PulsarMutationSender(config, true);
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        long c = Flux.from(connector.read()).flatMap(Resource::read).map(record -> {
+            //System.out.println("Sending to pulsar " + record.toString());
+            Object[] pkValues = new Object[]{record.getFieldValue(new DefaultIndexedField(0))};
+            DataOutputBuffer dataOutputBuffer = new DataOutputBuffer();
+            //org.apache.cassandra.db.Mutation.serializer.serialize(mutation, dataOutputBuffer, descriptor.getMessagingVersion());
+            //String md5Digest = DigestUtils.md5Hex(dataOutputBuffer.getData());
+            TableMetadata.Builder builder = TableMetadata.builder(exportedTable.keyspace.getName().toString(), exportedTable.table.getName().toString());
+            exportedTable.table.getPartitionKey().forEach(k-> builder.addPartitionKeyColumn(k.getName().toString(), UTF8Type.instance));
+            TableMetadata t = builder.build();
+            futures.add(sender.sendMutationAsync(new Mutation(UUID.randomUUID(), 0L, 0, pkValues, 0, "", t, "")));
+            return record;
+        }).count().block().longValue();
+
+        LOGGER.info("sent {} records to Pulsar", c);
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0])).join();
+        return new TableExportReport(migrator, ExitStatus.STATUS_OK, operationId, true);
+    }
+
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/TableExportReport.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/TableExportReport.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+public class TableExportReport {
+
+    private final TableExporter migrator;
+    private final ExitStatus status;
+    private final String operationId;
+    private final boolean export;
+
+    public TableExportReport(
+            TableExporter migrator, ExitStatus status, String operationId, boolean export) {
+        this.migrator = migrator;
+        this.status = status;
+        this.operationId = operationId;
+        this.export = export;
+    }
+
+    public TableExporter getMigrator() {
+        return migrator;
+    }
+
+    public boolean isExport() {
+        return export;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public ExitStatus getStatus() {
+        return status;
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/TableExporter.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/TableExporter.java
@@ -1,0 +1,316 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.cdc.backfill;
+
+import com.clearspring.analytics.stream.membership.DataOutputBuffer;
+import com.datastax.oss.cdc.agent.AgentConfig;
+import com.datastax.oss.cdc.agent.Mutation;
+import com.datastax.oss.cdc.agent.PulsarMutationSender;
+import com.datastax.oss.cdc.backfill.util.LoggingUtils;
+import com.datastax.oss.dsbulk.config.ConfigUtils;
+import com.datastax.oss.dsbulk.connectors.api.DefaultIndexedField;
+import com.datastax.oss.dsbulk.connectors.api.Resource;
+import com.datastax.oss.dsbulk.connectors.csv.CSVConnector;
+import com.datastax.oss.dsbulk.runner.DataStaxBulkLoader;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.schema.TableMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static com.datastax.oss.cdc.agent.AgentConfig.PULSAR_SERVICE_URL;
+
+public class TableExporter extends TableProcessor {
+    private static final URL DSBULK_CONFIGURATION_FILE =
+            Objects.requireNonNull(ClassLoader.getSystemResource("logback-dsbulk-embedded.xml"));
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableExporter.class);
+
+    protected final BackFillSettings settings;
+
+    protected final Path tableDataDir;
+
+    protected final Path exportAckDir;
+    protected final Path exportAckFile;
+
+    protected final Path importAckDir;
+    protected final Path importAckFile;
+
+    public TableExporter(ExportedTable exportedTable, BackFillSettings settings) {
+        super(exportedTable);
+        this.settings = settings;
+        this.tableDataDir =
+                settings
+                        .dataDir
+                        .resolve(exportedTable.keyspace.getName().asInternal())
+                        .resolve(exportedTable.table.getName().asInternal());
+        this.exportAckDir = settings.dataDir.resolve("__exported__");
+        this.importAckDir = settings.dataDir.resolve("__imported__");
+        this.exportAckFile =
+                exportAckDir.resolve(
+                        exportedTable.keyspace.getName().asInternal()
+                                + "__"
+                                + exportedTable.table.getName().asInternal()
+                                + ".exported");
+        this.importAckFile =
+                importAckDir.resolve(
+                        exportedTable.keyspace.getName().asInternal()
+                                + "__"
+                                + exportedTable.table.getName().asInternal()
+                                + ".imported");
+    }
+
+    public TableExportReport exportTable() {
+        String operationId;
+        if ((operationId = retrieveExportOperationId()) != null) {
+            LOGGER.warn(
+                    "Table {}.{}: already exported, skipping (delete this file to re-export: {}).",
+                    exportedTable.keyspace.getName(),
+                    exportedTable.table.getName(),
+                    exportAckFile);
+            return new TableExportReport(this, ExitStatus.STATUS_OK, operationId, true);
+        } else {
+            LOGGER.info("Exporting {}...", exportedTable.fullyQualifiedName);
+            operationId = createOperationId(true);
+            List<String> args = createExportArgs(operationId);
+            ExitStatus status = invokeDsbulk(operationId, args);
+            LOGGER.info("Export of {} finished with {}", exportedTable.fullyQualifiedName, status);
+            if (status == ExitStatus.STATUS_OK) {
+                createExportAckFile(operationId);
+            }
+            return new TableExportReport(this, status, operationId, true);
+        }
+    }
+    
+    public boolean isExported() {
+        return Files.exists(exportAckFile);
+    }
+
+    public boolean isImported() {
+        return Files.exists(importAckFile);
+    }
+
+    public ExitStatus invokeDsbulk(String operationId, List<String> args) {
+        DataStaxBulkLoader loader = new DataStaxBulkLoader(args.toArray(new String[0]));
+        int exitCode;
+        LoggingUtils.configureLogging(DSBULK_CONFIGURATION_FILE);
+        System.setProperty("OPERATION_ID", operationId);
+        try {
+            exitCode = loader.run().exitCode();
+        } finally {
+            System.clearProperty("OPERATION_ID");
+            LoggingUtils.configureLogging(LoggingUtils.MIGRATOR_CONFIGURATION_FILE);
+        }
+        return ExitStatus.forCode(exitCode);
+    }
+    private String createOperationId(boolean export) {
+        ZonedDateTime now = Instant.now().atZone(ZoneOffset.UTC);
+        String timestamp = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss_SSS").format(now);
+        return String.format(
+                "%s_%s_%s_%s",
+                (export ? "EXPORT" : "IMPORT"),
+                exportedTable.keyspace.getName().asInternal(),
+                exportedTable.table.getName().asInternal(),
+                timestamp);
+    }
+
+    private String retrieveExportOperationId() {
+        if (isExported()) {
+            try {
+                String operationId = new String(Files.readAllBytes(exportAckFile));
+                if (!(isBlankString(operationId))) {
+                    return operationId;
+                }
+            } catch (IOException ignored) {
+            }
+        }
+        return null;
+    }
+
+    boolean isBlankString(String string) {
+        return string == null || string.trim().isEmpty();
+    }
+
+    private void createExportAckFile(String operationId) {
+        try {
+            Files.createDirectories(exportAckDir);
+            Files.createFile(exportAckFile);
+            Files.write(exportAckFile, operationId.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void createImportAckFile(String operationId) {
+        try {
+            Files.createDirectories(importAckDir);
+            Files.createFile(importAckFile);
+            Files.write(importAckFile, operationId.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private boolean hasExportedData() {
+        if (isExported()) {
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(tableDataDir)) {
+                for (Path entry : stream) {
+                    String fileName = entry.getFileName().toString();
+                    if (fileName.startsWith("output")) {
+                        return true;
+                    }
+                }
+            } catch (IOException ignored) {
+            }
+        }
+        return false;
+    }
+
+    private List<String> createExportArgs(String operationId) {
+        List<String> args = new ArrayList<>();
+        args.add("unload");
+        if (settings.exportSettings.clusterInfo.bundle != null) {
+            args.add("-b");
+            args.add(String.valueOf(settings.exportSettings.clusterInfo.bundle));
+        } else {
+            args.add("-h");
+            String hosts =
+                    settings.exportSettings.clusterInfo.hostsAndPorts.stream()
+                            .map(hp -> "\"" + hp + "\"")
+                            .collect(Collectors.joining(","));
+            args.add("[" + hosts + "]");
+        }
+        if (settings.exportSettings.clusterInfo.protocolVersion != null) {
+            args.add("--driver.advanced.protocol.version");
+            args.add(settings.exportSettings.clusterInfo.protocolVersion);
+        }
+        if (settings.exportSettings.credentials != null) {
+            args.add("-u");
+            args.add(settings.exportSettings.credentials.username);
+            args.add("-p");
+            args.add(String.valueOf(settings.exportSettings.credentials.password));
+        }
+        args.add("-url");
+        args.add(String.valueOf(tableDataDir));
+        args.add("-maxRecords");
+        args.add(String.valueOf(settings.exportSettings.maxRecords));
+        args.add("-maxConcurrentFiles");
+        args.add(settings.exportSettings.maxConcurrentFiles);
+        args.add("-maxConcurrentQueries");
+        args.add(settings.exportSettings.maxConcurrentQueries);
+        args.add("--schema.splits");
+        args.add(settings.exportSettings.splits);
+        args.add("-cl");
+        args.add(String.valueOf(settings.exportSettings.consistencyLevel));
+        args.add("-maxErrors");
+        args.add("0");
+        args.add("-header");
+        args.add("true");
+        args.add("--engine.executionId");
+        args.add(operationId);
+        args.add("-logDir");
+        args.add(String.valueOf(settings.dsbulkLogDir));
+        args.add("-query");
+        args.add(buildExportQuery());
+        args.add("--dsbulk.monitoring.console");
+        args.add("false");
+        args.addAll(settings.exportSettings.extraDsbulkOptions);
+        return args;
+    }
+
+    private List<String> createImportArgs(String operationId) {
+        List<String> args = new ArrayList<>();
+        args.add("load");
+        if (settings.exportSettings.clusterInfo.bundle != null) {
+            args.add("-b");
+            args.add(String.valueOf(settings.exportSettings.clusterInfo.bundle));
+        } else {
+            args.add("-h");
+            String hosts =
+                    settings.exportSettings.clusterInfo.hostsAndPorts.stream()
+                            .map(hp -> "\"" + hp + "\"")
+                            .collect(Collectors.joining(","));
+            args.add("[" + hosts + "]");
+        }
+        if (settings.exportSettings.clusterInfo.protocolVersion != null) {
+            args.add("--driver.advanced.protocol.version");
+            args.add(settings.exportSettings.clusterInfo.protocolVersion);
+        }
+        if (settings.exportSettings.credentials != null) {
+            args.add("-u");
+            args.add(settings.exportSettings.credentials.username);
+            args.add("-p");
+            args.add(String.valueOf(settings.exportSettings.credentials.password));
+        }
+        args.add("-url");
+        args.add(String.valueOf(tableDataDir));
+        args.add("-maxRecords");
+        args.add(String.valueOf(settings.exportSettings.maxRecords));
+        args.add("-maxConcurrentFiles");
+        args.add(settings.exportSettings.maxConcurrentFiles);
+        args.add("-maxConcurrentQueries");
+        args.add(settings.exportSettings.maxConcurrentQueries);
+        args.add("--schema.splits");
+        args.add(settings.exportSettings.splits);
+        args.add("-cl");
+        args.add(String.valueOf(settings.exportSettings.consistencyLevel));
+        args.add("-maxErrors");
+        args.add("0");
+        args.add("-header");
+        args.add("false");
+        args.add("--engine.executionId");
+        args.add(operationId);
+        args.add("-logDir");
+        args.add(String.valueOf(settings.dsbulkLogDir));
+        args.add("-query");
+        args.add(buildExportQuery());
+        args.add("--dsbulk.monitoring.console");
+        args.add("false");
+        args.addAll(settings.exportSettings.extraDsbulkOptions);
+        return args;
+    }
+
+    @Override
+    protected String escape(String text) {
+        return text.replace("\"", "\\\"");
+    }
+}
+

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/TableProcessor.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/TableProcessor.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import java.util.Iterator;
+
+public abstract class TableProcessor {
+
+    protected final ExportedTable exportedTable;
+
+    public TableProcessor(ExportedTable exportedTable) {
+        this.exportedTable = exportedTable;
+    }
+
+    public ExportedTable getExportedTable() {
+        return exportedTable;
+    }
+
+    protected String buildExportQuery() {
+        StringBuilder builder = new StringBuilder("\"SELECT ");
+        Iterator<ExportedColumn> cols = exportedTable.columns.iterator();
+        while (cols.hasNext()) {
+            ExportedColumn exportedColumn = cols.next();
+            String name = escape(exportedColumn.col.getName());
+            builder.append(name);
+            if (exportedColumn.writetime != null) {
+                builder.append(", WRITETIME(");
+                builder.append(name);
+                builder.append(") AS ");
+                builder.append(escape(exportedColumn.writetime));
+            }
+            if (exportedColumn.ttl != null) {
+                builder.append(", TTL(");
+                builder.append(name);
+                builder.append(") AS ");
+                builder.append(escape(exportedColumn.ttl));
+            }
+            if (cols.hasNext()) {
+                builder.append(", ");
+            }
+        }
+        builder.append(" FROM ");
+        builder.append(escape(exportedTable.keyspace.getName()));
+        builder.append(".");
+        builder.append(escape(exportedTable.table.getName()));
+        builder.append("\"");
+        return builder.toString();
+    }
+
+    protected String escape(CqlIdentifier id) {
+        return escape(id.asCql(true));
+    }
+
+    protected abstract String escape(String id);
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/VersionProvider.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/VersionProvider.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.cdc.backfill;
+
+import picocli.CommandLine;
+
+public class VersionProvider implements CommandLine.IVersionProvider {
+
+    @Override
+    public String[] getVersion() {
+        return new String[] {
+                "CDC Backfill CLI V0.0.1" ,
+                "Java version: ${java.version}, ${java.vendor} (${java.vm.name} version ${java.vm.version})",
+                "OS: ${os.name} version ${os.version} (${os.arch})",
+                "(C) DataStax"
+        };
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/ConnectorUtils.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/ConnectorUtils.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.util;
+
+import com.datastax.oss.dsbulk.config.ConfigUtils;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class ConnectorUtils {
+
+    public static Config createConfig(String path, Object... additionalArgs) {
+        Config baseConfig = ConfigUtils.createApplicationConfig(null).resolve().getConfig(path);
+        if (additionalArgs != null && additionalArgs.length != 0) {
+            Iterator<Object> it = Arrays.asList(additionalArgs).iterator();
+            while (it.hasNext()) {
+                Object key = it.next();
+                Object value = it.next();
+                baseConfig =
+                        ConfigFactory.parseString(
+                                        key + "=" + value,
+                                        ConfigParseOptions.defaults().setOriginDescription("command line argument"))
+                                .withFallback(baseConfig);
+            }
+        }
+        return baseConfig;
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/LoggingUtils.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/LoggingUtils.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.util;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+public class LoggingUtils {
+
+    public static final URL MIGRATOR_CONFIGURATION_FILE;
+
+    static {
+        try {
+            MIGRATOR_CONFIGURATION_FILE =
+                    Objects.requireNonNull(
+                            System.getProperty("logback. configurationFile") == null
+                                    ? ClassLoader.getSystemResource("logback-cdc-backfill.xml")
+                                    : Paths.get(System.getProperty("logback. configurationFile")).toUri().toURL());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void configureLogging(URL configurationFile) {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        loggerContext.reset();
+        JoranConfigurator configurator = new JoranConfigurator();
+        try (InputStream configStream = configurationFile.openStream()) {
+            configurator.setContext(loggerContext);
+            configurator.doConfigure(configStream);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to configure logging", e);
+        }
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/ModelUtils.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/ModelUtils.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.cdc.backfill.util;
+
+import com.datastax.oss.cdc.backfill.BackFillSettings;
+import com.datastax.oss.cdc.backfill.ClusterInfo;
+import com.datastax.oss.cdc.backfill.Credentials;
+import com.datastax.oss.cdc.backfill.ExportedColumn;
+import com.datastax.oss.cdc.backfill.ExportedTable;
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.core.type.ListType;
+import com.datastax.oss.driver.api.core.type.MapType;
+import com.datastax.oss.driver.api.core.type.SetType;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ModelUtils {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(ModelUtils.class);
+
+    public static ExportedTable buildExportedTable(
+            ClusterInfo origin, Credentials credentials, BackFillSettings inclusionSettings) {
+        try (CqlSession session = SessionUtils.createSession(origin, credentials)) {
+            LOGGER.info("Tables to migrate:");
+            KeyspaceMetadata keyspace = getExportedKeyspace(session, inclusionSettings);
+            TableMetadata table = getExportedTablesInKeyspace(keyspace, inclusionSettings);
+            List<ExportedColumn> exportedColumns = buildExportedPKColumns(table);
+            ExportedTable exportedTable = new ExportedTable(keyspace, table, exportedColumns);
+            LOGGER.info(
+                    "- {} ({})", exportedTable, "regular");
+            return exportedTable;
+        }
+    }
+
+    private static KeyspaceMetadata getExportedKeyspace(
+            CqlSession session, BackFillSettings settings) {
+        return session.getMetadata().getKeyspace(settings.keyspace).get();
+    }
+
+    private static TableMetadata getExportedTablesInKeyspace(
+            KeyspaceMetadata keyspace, BackFillSettings settings) {
+
+        //TableType tableType = settings.getTableType();
+        return keyspace.getTable(settings.table).get();
+    }
+
+    private static List<ExportedColumn> buildExportedPKColumns(
+            TableMetadata table) {
+        List<ExportedColumn> exportedColumns = new ArrayList<>();
+        for (ColumnMetadata pk : table.getPrimaryKey()) {
+            exportedColumns.add(new ExportedColumn(pk, true, null, null));
+        }
+        return exportedColumns;
+    }
+}

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/SessionUtils.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/SessionUtils.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.cdc.backfill.util;
+
+
+import com.datastax.oss.cdc.backfill.ClusterInfo;
+import com.datastax.oss.cdc.backfill.Credentials;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBuilder;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SessionUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SessionUtils.class);
+
+    public static CqlSession createSession(ClusterInfo clusterInfo, Credentials credentials) {
+        String clusterName = clusterInfo.isOrigin() ? "origin" : "target";
+        try {
+            LOGGER.info("Contacting {} cluster...", clusterName);
+            CqlSession session = createSessionBuilder(clusterInfo, credentials).build();
+            LOGGER.info("Successfully contacted {} cluster", clusterName);
+            return session;
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not contact " + clusterName + " cluster", e);
+        }
+    }
+
+    private static CqlSessionBuilder createSessionBuilder(
+            ClusterInfo clusterInfo, Credentials credentials) {
+        ProgrammaticDriverConfigLoaderBuilder configLoaderBuilder =
+                DriverConfigLoader.programmaticBuilder()
+                        .withString(
+                                DefaultDriverOption.SESSION_NAME, clusterInfo.isOrigin() ? "origin" : "target")
+                        .withString(
+                                DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS, "DcInferringLoadBalancingPolicy");
+        if (clusterInfo.getProtocolVersion() != null) {
+            configLoaderBuilder =
+                    configLoaderBuilder.withString(
+                            DefaultDriverOption.PROTOCOL_VERSION, clusterInfo.getProtocolVersion());
+        }
+        DriverConfigLoader configLoader = configLoaderBuilder.build();
+        CqlSessionBuilder sessionBuilder = CqlSession.builder().withConfigLoader(configLoader);
+        if (clusterInfo.isAstra()) {
+            sessionBuilder.withCloudSecureConnectBundle(clusterInfo.getBundle());
+        } else {
+            List<InetSocketAddress> contactPoints = clusterInfo.getContactPoints();
+            sessionBuilder.addContactPoints(contactPoints);
+            // limit connectivity to just the contact points to limit network I/O
+            // TODO: Understand better the node filter and update to NodeDistanceEvaluator instead:
+            // https://docs.datastax.com/en/developer/java-driver/4.11/upgrade_guide/
+            //sessionBuilder.withNodeFilter(
+            //        node -> {
+            //            SocketAddress address = node.getEndPoint().resolve();
+            //            return address instanceof InetSocketAddress && contactPoints.contains(address);
+            //        });
+        }
+        if (credentials != null) {
+            sessionBuilder.withAuthCredentials(
+                    credentials.getUsername(), String.valueOf(credentials.getPassword()));
+        }
+        return sessionBuilder;
+    }
+}
+

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/TableUtils.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/util/TableUtils.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.util;
+
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+
+public class TableUtils {
+
+    public static String getFullyQualifiedTableName(TableMetadata table) {
+        return String.format("%s.%s", table.getKeyspace().asCql(true), table.getName().asCql(true));
+    }
+
+    public static boolean isCounterTable(TableMetadata table) {
+        return table.getColumns().values().stream()
+                .anyMatch(column -> column.getType() == DataTypes.COUNTER);
+    }
+}

--- a/cdc-backfill-client/src/main/resources/logback-cdc-backfill.xml
+++ b/cdc-backfill-client/src/main/resources/logback-cdc-backfill.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+    <logger name="com.datastax.oss.cdc" level="INFO"/>
+    <logger name="com.datastax.oss.dsbulk" level="WARN"/>
+    <logger name="com.datastax.oss.driver" level="WARN"/>
+    <logger name="com.datastax.dse.driver" level="WARN"/>
+</configuration>

--- a/cdc-backfill-client/src/main/resources/logback-dsbulk-embedded.xml
+++ b/cdc-backfill-client/src/main/resources/logback-dsbulk-embedded.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+    <!--
+    This is a copy of DSBulk's original log configuration file, with minimal changes to make it
+    more suitable for the migrator tool, when using the embedded DSBulk runtime.
+    -->
+    <property name="OPERATION_ID" value=""/>
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <!--
+        DSBulk log messages are printed to standard error, to leave standard out free for
+        output from workflow executions that print their results to that channel.
+        But in this tool, it is safe to use System.out.
+        -->
+        <target>System.out</target>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <!--
+        Don't print metrics on the console.
+        -->
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>METRICS</marker>
+            </evaluator>
+            <onMismatch>NEUTRAL</onMismatch>
+            <onMatch>DENY</onMatch>
+        </filter>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [DSBULK-%property{OPERATION_ID}] %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+    <root level="ERROR">
+        <!--
+        DSBulk also logs to a main log file, but this appender is
+        created programmatically in LogSettings.
+        -->
+        <appender-ref ref="CONSOLE"/>
+    </root>
+    <!--
+    Do not change the loggers below; they are programmatically manipulated
+    by LogSettings to apply the desired verbosity level.
+    -->
+    <logger name="com.datastax.oss.dsbulk" level="INFO"/>
+    <logger name="com.datastax.oss.driver" level="WARN"/>
+    <logger name="com.datastax.dse.driver" level="WARN"/>
+    <logger name="io.netty" level="WARN"/>
+    <logger name="reactor.core" level="WARN"/>
+</configuration>

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,3 +42,6 @@ cdc_total_space_in_mb=70
 
 # default docker repo + slash
 dockerRepo=myrepo/
+
+# CDC backfilling Client
+dsbulkVersion=1.10.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "io.github.lhotari.gradle-nar-plugin:gradle-nar-plugin:0.5.1"
-        classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+        classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
         classpath "com.avast.gradle:gradle-docker-compose-plugin:0.14.9"
 
         // workaround for issue https://github.com/n0mer/gradle-git-properties/issues/195
@@ -35,3 +35,4 @@ include 'connector-distribution'
 
 include 'docs'
 
+include 'cdc-backfill-client'


### PR DESCRIPTION
Initial skeleton for the CDC backfill CLI tool:
* CLI take dependency on DSBulk to export the data to desk and start a CVS connector for the
* This PR shows the end to end skeleton to get early feedback on the project skeleton and over all approach, unit tests/refactoring are coming up.
* Will local DSE and Pulsar, the following command should run e2e:

```
./gradlew cdc-backfill-client:assemble
java  -jar cdc-backfill-client/build/libs/cdc-backfill-client-2.2.3-all.jar backfill --data-dir=target/export --export-host=127.0.0.1:9042 --export-username=cassandra --export-password=cassandra --keyspace ks1 --table sample1
```
* Lots of settings are imported as is from DSBulk - will reduce those to the bare minimum
* Parts of the codes assumes multiple table migrations concurrently, this could be be simplified on the first iteration
* Checkpointing comes backed in from DSE
* Integ tests/Pulsar admin CLI integ will be covered in a separate series of PRs one we get the skeleton gets into a reasonable state.  