### PR TITLE
Convert CVS (String) types to CQL java types

### DIFF
--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/exporter/ExportedTable.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/exporter/ExportedTable.java
@@ -16,6 +16,7 @@
 
 package com.datastax.oss.cdc.backfill.exporter;
 
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.google.common.collect.ImmutableMap;
@@ -70,10 +71,10 @@ public class ExportedTable {
             .put(TimeUUIDType.instance.asCQL3Type().toString(), TimeUUIDType.instance)
             .build();
 
-    public final KeyspaceMetadata keyspace;
-    public final TableMetadata table;
-    public final List<ExportedColumn> columns;
-    public final String fullyQualifiedName;
+    private final KeyspaceMetadata keyspace;
+    private final TableMetadata table;
+    private final List<ExportedColumn> columns;
+    private final String fullyQualifiedName;
 
     public ExportedTable(
             KeyspaceMetadata keyspace, TableMetadata table, List<ExportedColumn> columns) {
@@ -88,7 +89,7 @@ public class ExportedTable {
      * Adapts the {@link TableMetadata} to {@link org.apache.cassandra.schema.TableMetadata} to be used with pulsar
      * importer
      */
-    public org.apache.cassandra.schema.TableMetadata getCassandraSchemaTable() {
+    public org.apache.cassandra.schema.TableMetadata getCassandraTable() {
         org.apache.cassandra.schema.TableMetadata.Builder builder =
                 org.apache.cassandra.schema.TableMetadata.builder(
                         keyspace.getName().toString(),
@@ -101,6 +102,26 @@ public class ExportedTable {
                 builder.addClusteringColumn(k.getName().toString(),
                         getAbstractDataType(k.getType().asCql(false, true))));
         return builder.build();
+    }
+
+    public KeyspaceMetadata getKeyspace() {
+        return keyspace;
+    }
+
+    public TableMetadata getTable() {
+        return table;
+    }
+
+    public List<ExportedColumn> getColumns() {
+        return columns;
+    }
+
+    public List<ColumnMetadata> getPrimaryKey() {
+        return table.getPrimaryKey();
+    }
+
+    public String getName(){
+        return this.table.getName().asInternal();
     }
 
     private AbstractType<?>  getAbstractDataType(String asCql) {

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/exporter/TableExporter.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/exporter/TableExporter.java
@@ -70,14 +70,14 @@ public class TableExporter {
         this.tableDataDir =
                 settings
                         .dataDir
-                        .resolve(exportedTable.keyspace.getName().asInternal())
-                        .resolve(exportedTable.table.getName().asInternal());
+                        .resolve(exportedTable.getKeyspace().getName().asInternal())
+                        .resolve(exportedTable.getTable().getName().asInternal());
         this.exportAckDir = settings.dataDir.resolve("__exported__");
         this.exportAckFile =
                 exportAckDir.resolve(
-                        exportedTable.keyspace.getName().asInternal()
+                        exportedTable.getKeyspace().getName().asInternal()
                                 + "__"
-                                + exportedTable.table.getName().asInternal()
+                                + exportedTable.getTable().getName().asInternal()
                                 + ".exported");
     }
 
@@ -86,16 +86,16 @@ public class TableExporter {
         if (operationId != null) {
             LOGGER.warn(
                     "Table {}.{}: already exported, skipping (delete this file to re-export: {}).",
-                    exportedTable.keyspace.getName(),
-                    exportedTable.table.getName(),
+                    exportedTable.getKeyspace().getName(),
+                    exportedTable.getTable().getName(),
                     exportAckFile);
             return ExitStatus.STATUS_OK;
         } else {
-            LOGGER.info("Exporting {}...", exportedTable.fullyQualifiedName);
+            LOGGER.info("Exporting {}...", exportedTable);
             operationId = createOperationId();
             List<String> args = createExportArgs(operationId);
             ExitStatus status = invokeDsbulk(operationId, args);
-            LOGGER.info("Export of {} finished with {}", exportedTable.fullyQualifiedName, status);
+            LOGGER.info("Export of {} finished with {}", exportedTable, status);
             if (status == ExitStatus.STATUS_OK) {
                 createExportAckFile(operationId);
             }
@@ -134,8 +134,8 @@ public class TableExporter {
         return String.format(
                 "%s_%s_%s_%s",
                 "EXPORT" ,
-                exportedTable.keyspace.getName().asInternal(),
-                exportedTable.table.getName().asInternal(),
+                exportedTable.getKeyspace().getName().asInternal(),
+                exportedTable.getTable().getName().asInternal(),
                 timestamp);
     }
 
@@ -226,7 +226,7 @@ public class TableExporter {
 
     protected String buildExportQuery() {
         StringBuilder builder = new StringBuilder("SELECT ");
-        Iterator<ExportedColumn> cols = exportedTable.columns.iterator();
+        Iterator<ExportedColumn> cols = exportedTable.getColumns().iterator();
         while (cols.hasNext()) {
             ExportedColumn exportedColumn = cols.next();
             String name = escape(exportedColumn.col.getName());
@@ -236,9 +236,9 @@ public class TableExporter {
             }
         }
         builder.append(" FROM ");
-        builder.append(escape(exportedTable.keyspace.getName()));
+        builder.append(escape(exportedTable.getKeyspace().getName()));
         builder.append(".");
-        builder.append(escape(exportedTable.table.getName()));
+        builder.append(escape(exportedTable.getTable().getName()));
 
         return builder.toString();
     }

--- a/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/factory/BackfillFactory.java
+++ b/cdc-backfill-client/src/main/java/com/datastax/oss/cdc/backfill/factory/BackfillFactory.java
@@ -58,7 +58,7 @@ public class BackfillFactory {
     }
 
     public PulsarImporter createPulsarImporter(Connector connector, ExportedTable exportedTable) {
-        return new PulsarImporter(connector, exportedTable.getCassandraSchemaTable(),
+        return new PulsarImporter(connector, exportedTable,
                 new PulsarMutationSenderFactory(settings.importSettings));
     }
 }

--- a/cdc-backfill-client/src/test/resources/sample-002.csv
+++ b/cdc-backfill-client/src/test/resources/sample-002.csv
@@ -1,0 +1,3 @@
+xtext,xboolean,xint
+vtext,1,2
+v2text,0,3


### PR DESCRIPTION
This patch adds support for converting the exported CVS values to their CQL java types by leveraging `ConvertingCodec`. It also adds a unit test with PK + Clustering keys containing different types.  