### PR TITLE
[security] Upgrade jackson and kafka-clients

### DIFF
--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -44,10 +44,10 @@ dependencies {
     compileOnly("${pulsarGroup}:pulsar-client-original:${pulsarVersion}")
     compileOnly("${pulsarGroup}:pulsar-io-common:${pulsarVersion}")
     compileOnly("${pulsarGroup}:pulsar-io-core:${pulsarVersion}")
+    implementation(platform("com.fasterxml.jackson:jackson-bom:${jacksonBomVersion}"))
 
     constraints {
         implementation("ch.qos.logback:logback-classic:${logbackVersion}")
-        implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}")
         implementation("com.github.jnr:jnr-posix:${jnrVersion}")
         implementation("io.netty:netty-handler:${nettyVersion}")
         implementation("io.netty:netty-transport-native-epoll:${nettyVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ pulsarVersion=2.8.3
 testPulsarImage=datastax/lunastreaming
 testPulsarImageTag=2.8.0_1.1.42
 
-kafkaVersion=2.5.1
+kafkaVersion=3.4.0
 vavrVersion=0.10.3
 testContainersVersion=1.16.2
 caffeineVersion=2.8.8
@@ -28,7 +28,7 @@ messagingConnectorsCommonsVersion=1.0.14
 slf4jVersion=1.7.30
 # pulsar connector
 logbackVersion=1.2.9
-jacksonDatabindVersion=2.12.7.1
+jacksonBomVersion=2.13.4.20221013
 jnrVersion=3.1.15
 nettyVersion=4.1.72.Final
 nettyTcNativeVersion=2.0.46.Final


### PR DESCRIPTION
* move to jackson BOM 2.13.4 to avoid CVEs
* `messaging-connectors-commons` depends on `kafka-clients` for the config. 2.5.1 contains CVE-2023-25194.
Upgrade to 3.4.0