### PR TITLE
Update the pulsar ci test matrix

### DIFF
--- a/.github/workflows/backfill-ci.yaml
+++ b/.github/workflows/backfill-ci.yaml
@@ -75,6 +75,8 @@ jobs:
           IFS=$PREV_IFS
           PULSAR_IMAGE=${PULSAR_FULL_IMAGE[0]}
           PULSAR_IMAGE_VERSION=${PULSAR_FULL_IMAGE[1]}
+
+          echo "Running tests, pulsar: ${{ matrix.pulsarImage }}, pulsar image: $PULSAR_IMAGE, pulsar image tag: $PULSAR_IMAGE_TAG, cassandra: ${{ matrix.cassandraFamily }}"  
           
           ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
           -PtestPulsarImage=$PULSAR_IMAGE \

--- a/.github/workflows/backfill-ci.yaml
+++ b/.github/workflows/backfill-ci.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: ['11'] # TODO: Enable java 17 tests https://issues.apache.org/jira/browse/CASSANDRA-16895
-        pulsarImage: ['datastax/lunastreaming:2.10_2.4', 'apachepulsar/pulsar:2.10.3', 'apachepulsar/pulsar:2.11.0']
+        pulsarImage: ['datastax/lunastreaming:2.10_3.4', 'apachepulsar/pulsar:2.10.3', 'apachepulsar/pulsar:2.11.0']
         cassandraFamily: ['c3', 'c4', 'dse4']
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/backfill-ci.yaml
+++ b/.github/workflows/backfill-ci.yaml
@@ -75,8 +75,6 @@ jobs:
           IFS=$PREV_IFS
           PULSAR_IMAGE=${PULSAR_FULL_IMAGE[0]}
           PULSAR_IMAGE_TAG=${PULSAR_FULL_IMAGE[1]}
-
-          echo "Running tests, pulsar image: $PULSAR_IMAGE, pulsar image tag: $PULSAR_IMAGE_TAG, cassandra: ${{ matrix.cassandraFamily }}"  
           
           ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
           -PtestPulsarImage=$PULSAR_IMAGE \

--- a/.github/workflows/backfill-ci.yaml
+++ b/.github/workflows/backfill-ci.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: ['11'] # TODO: Enable java 17 tests https://issues.apache.org/jira/browse/CASSANDRA-16895
-        pulsarImageTag: ['2.10_0.4']
+        pulsarImage: ['datastax/lunastreaming:2.10_2.4', 'apachepulsar/pulsar:2.10.3', 'apachepulsar/pulsar:2.11.0']
         cassandraFamily: ['c3', 'c4', 'dse4']
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +68,16 @@ jobs:
           DSE_REPO_USERNAME: ${{ secrets.DSE_REPO_USERNAME }}
           DSE_REPO_PASSWORD: ${{ secrets.DSE_REPO_PASSWORD }}
         run: |
+          set -e
+          PREV_IFS=$IFS
+          IFS=':'
+          read -ra PULSAR_FULL_IMAGE <<< "${{ matrix.pulsarImage }}"
+          IFS=$PREV_IFS
+          PULSAR_IMAGE=${PULSAR_FULL_IMAGE[0]}
+          PULSAR_IMAGE_VERSION=${PULSAR_FULL_IMAGE[1]}
+          
           ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
-          -PpulsarImageTag=${{ matrix.pulsarImageTag }} \
+          -PtestPulsarImage=$PULSAR_IMAGE \
+          -PtestPulsarImageTag=$PULSAR_IMAGE_TAG \
           -PcassandraFamily=${{ matrix.cassandraFamily }} \
           backfill-cli:e2eTest

--- a/.github/workflows/backfill-ci.yaml
+++ b/.github/workflows/backfill-ci.yaml
@@ -74,9 +74,9 @@ jobs:
           read -ra PULSAR_FULL_IMAGE <<< "${{ matrix.pulsarImage }}"
           IFS=$PREV_IFS
           PULSAR_IMAGE=${PULSAR_FULL_IMAGE[0]}
-          PULSAR_IMAGE_VERSION=${PULSAR_FULL_IMAGE[1]}
+          PULSAR_IMAGE_TAG=${PULSAR_FULL_IMAGE[1]}
 
-          echo "Running tests, pulsar: ${{ matrix.pulsarImage }}, pulsar image: $PULSAR_IMAGE, pulsar image tag: $PULSAR_IMAGE_TAG, cassandra: ${{ matrix.cassandraFamily }}"  
+          echo "Running tests, pulsar image: $PULSAR_IMAGE, pulsar image tag: $PULSAR_IMAGE_TAG, cassandra: ${{ matrix.cassandraFamily }}"  
           
           ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
           -PtestPulsarImage=$PULSAR_IMAGE \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         module: ['agent', 'agent-c3', 'agent-c4', 'agent-dse4', 'connector']
         jdk: ['11', '17']
-        pulsarImage: ['datastax/lunastreaming:2.10_2.4', 'apachepulsar/pulsar:2.10.3', 'apachepulsar/pulsar:2.11.0']
+        pulsarImage: ['datastax/lunastreaming:2.10_3.4', 'apachepulsar/pulsar:2.10.3', 'apachepulsar/pulsar:2.11.0']
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         module: ['agent', 'agent-c3', 'agent-c4', 'agent-dse4', 'connector']
         jdk: ['11', '17']
-        pulsarImageTag: ['2.8.0_1.1.42', '2.8.3_1.0.11', '2.10_0.4']
+        pulsarImage: ['datastax/lunastreaming:2.10_2.4', 'apachepulsar/pulsar:2.10.3', 'apachepulsar/pulsar:2.11.0']
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}
@@ -68,6 +68,15 @@ jobs:
           DSE_REPO_USERNAME: ${{ secrets.DSE_REPO_USERNAME }}
           DSE_REPO_PASSWORD: ${{ secrets.DSE_REPO_PASSWORD }}
         run: |
+          set -e
+          PREV_IFS=$IFS
+          IFS=':'
+          read -ra PULSAR_FULL_IMAGE <<< "${{ matrix.pulsarImage }}"
+          IFS=$PREV_IFS
+          PULSAR_IMAGE=${PULSAR_FULL_IMAGE[0]}
+          PULSAR_IMAGE_VERSION=${PULSAR_FULL_IMAGE[1]}
+          
           ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
-          -PpulsarImageTag=${{ matrix.pulsarImageTag }} \
+          -PtestPulsarImage=$PULSAR_IMAGE \
+          -PtestPulsarImageTag=$PULSAR_IMAGE_TAG \
           ${{ matrix.module }}:test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,9 +75,7 @@ jobs:
           IFS=$PREV_IFS
           PULSAR_IMAGE=${PULSAR_FULL_IMAGE[0]}
           PULSAR_IMAGE_TAG=${PULSAR_FULL_IMAGE[1]}
-          
-          echo "Running tests, pulsar image: $PULSAR_IMAGE, pulsar image tag: $PULSAR_IMAGE_TAG, cassandra: ${{ matrix.cassandraFamily }}"
-          
+                    
           ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
           -PtestPulsarImage=$PULSAR_IMAGE \
           -PtestPulsarImageTag=$PULSAR_IMAGE_TAG \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,9 @@ jobs:
           read -ra PULSAR_FULL_IMAGE <<< "${{ matrix.pulsarImage }}"
           IFS=$PREV_IFS
           PULSAR_IMAGE=${PULSAR_FULL_IMAGE[0]}
-          PULSAR_IMAGE_VERSION=${PULSAR_FULL_IMAGE[1]}
+          PULSAR_IMAGE_TAG=${PULSAR_FULL_IMAGE[1]}
+          
+          echo "Running tests, pulsar image: $PULSAR_IMAGE, pulsar image tag: $PULSAR_IMAGE_TAG, cassandra: ${{ matrix.cassandraFamily }}"
           
           ./gradlew -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
           -PtestPulsarImage=$PULSAR_IMAGE \


### PR DESCRIPTION
Update the pulsar ci test matrix:
- `datastax/lunastreaming:2.10_2.4`
- `apachepulsar/pulsar:2.10.3`
- `apachepulsar/pulsar:2.11.0`

Please note that previous, the test matrix was not taking affect and all tests ran against `datastax/lunastreaming:2.8.0_1.1.42` due to misconfiguration in the CI files. 