### PR TITLE
Add cassandra-cdc backfill command as a Pulsar Admin Extension

### DIFF
--- a/backfill-cli/build.gradle
+++ b/backfill-cli/build.gradle
@@ -23,6 +23,26 @@ shadowJar {
         resource = 'dsbulk-reference.conf'
     }
 
+    transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer) {
+        resource = 'driver-reference.conf'
+    }
+
+    dependencies {
+        // Exclude log4j from the shadow jar. This is optional step and meant to reduce the size of the nar.
+        exclude "org/apache/logging/**"
+        exclude "org/apache/log4j/**"
+        exclude "org/apache/commons/logging/**"
+        // relocate doesn't work if the target exist
+        exclude 'com/datastax/oss/dsbulk/workflow/commons/settings/LogSettings.class'
+        exclude 'com/datastax/oss/dsbulk/workflow/commons/settings/LogSettings$1.class'
+    }
+
+    // Change the behavior LogSettings to skip logback configuration if it is not bound at runtime
+    //relocate 'com.datastax.oss.cdc.backfill.dsbulk.LogSettings', 'com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings'
+    relocate('com.datastax.oss.cdc.backfill.dsbulk', 'com.datastax.oss.dsbulk.workflow.commons.settings') {
+        include 'com.datastax.oss.cdc.backfill.dsbulk.LogSettings**'
+    }
+
     zip64=true
 }
 
@@ -61,6 +81,8 @@ dependencies {
     implementation "org.apache.cassandra:cassandra-all:${cassandra4Version}"
     implementation "com.datastax.dse:dse-db:${dse4Version}"
     implementation "${pulsarGroup}:pulsar-client:${pulsarVersion}"
+    implementation "${pulsarGroup}:pulsar-client-tools-api:${pulsarVersion}"
+
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.1"
     testImplementation "org.mockito:mockito-core:3.11.1"
     testImplementation "com.datastax.oss:dsbulk-tests:${dsbulkVersion}"
@@ -71,6 +93,26 @@ dependencies {
     testImplementation("${pulsarGroup}:pulsar-client:${pulsarVersion}")
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.1"
+}
+
+// Custom nar task that wraps the shadowJar for pulsar admin extension purposes.
+tasks.register('nar', Zip) {
+    // bundle the shadow jar as is
+    from(shadowJar.archivePath) {
+        into "META-INF/bundled-dependencies"
+    }
+
+    // bundle metadata and command_factory.yaml files
+    sourceSets.main.resources.include("META-INF/**").each {
+        def splitPath = it.parent.split("META-INF")
+        def relativeParentDir = splitPath.length > 1 ? splitPath.last() : ""
+        from(it) {
+            into "META-INF" + relativeParentDir
+        }
+    }
+
+    archiveName "pulsar-cassandra-admin-${project.version}-nar.nar"
+    destinationDir file("${buildDir}/libs")
 }
 
 test {

--- a/backfill-cli/gradle.properties
+++ b/backfill-cli/gradle.properties
@@ -1,2 +1,4 @@
 artifact=backfill-cli
 mainClassName=com.datastax.oss.cdc.backfill.BackfillCLI
+
+pulsarVersion=2.11.0

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/admin/BackfillCommand.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/admin/BackfillCommand.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.admin;
+
+import com.datastax.oss.cdc.backfill.BackfillCLI;
+import org.apache.pulsar.admin.cli.extensions.CommandExecutionContext;
+import org.apache.pulsar.admin.cli.extensions.CustomCommand;
+import org.apache.pulsar.admin.cli.extensions.ParameterDescriptor;
+import org.apache.pulsar.admin.cli.extensions.ParameterType;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BackfillCommand implements CustomCommand {
+    @Override
+    public String name() {
+        return "backfill";
+    }
+
+    @Override
+    public String description() {
+        return "Backfills the CDC data topic with historical data from that source Cassandra table.";
+    }
+
+    @Override
+    public List<ParameterDescriptor> parameters() {
+        List<ParameterDescriptor> parameters = new ArrayList<>();
+        parameters.add(
+                ParameterDescriptor.builder()
+                        .description("The directory where data will be exported to and imported from")
+                        .type(ParameterType.STRING)
+                        .names(Arrays.asList("--data-dir", "-d"))
+                        .required(false)
+                        .build());
+        parameters.add(
+                ParameterDescriptor.builder()
+                        .description(
+                                "The host name or IP and, optionally, the port of a node from the origin cluster. " +
+                                "If the port is not specified, it will default to 9042.")
+                        .type(ParameterType.STRING)
+                        .names(Arrays.asList("--export-host"))
+                        .required(true)
+                        .build());
+        parameters.add(
+                ParameterDescriptor.builder()
+                        .description(
+                                "The username to use to authenticate against the origin cluster.")
+                        .type(ParameterType.STRING)
+                        .names(Arrays.asList("--export-username"))
+                        .required(true)
+                        .build());
+        parameters.add(
+                ParameterDescriptor.builder()
+                        .description(
+                                "The password to use to authenticate against the origin cluster.")
+                        .type(ParameterType.STRING)
+                        .names(Arrays.asList("--export-password"))
+                        .required(true)
+                        .build());
+        parameters.add(
+                ParameterDescriptor.builder()
+                        .description("The name of the keyspace where the table to be exported exists")
+                        .type(ParameterType.STRING)
+                        .names(Arrays.asList("--keyspace", "-k"))
+                        .required(true)
+                        .build());
+        parameters.add(
+                ParameterDescriptor.builder()
+                        .description("The name of the table to export data from for cdc back filling")
+                        .type(ParameterType.STRING)
+                        .names(Arrays.asList("--table", "-t"))
+                        .required(true)
+                        .build());
+        return parameters;
+    }
+
+    @Override
+    public boolean execute(Map<String, Object> parameters, CommandExecutionContext context) {
+        CommandLine commandLine = new CommandLine(new BackfillCLI());
+        List<String> args = parameters.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                        .collect(Collectors.toList());
+        args.add(0, "backfill");
+        int exitCode = commandLine.execute(args.toArray(new String[0]));
+        return exitCode == 0;
+    }
+}

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/admin/CommandFactory.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/admin/CommandFactory.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.admin;
+
+import org.apache.pulsar.admin.cli.extensions.CommandExecutionContext;
+import org.apache.pulsar.admin.cli.extensions.CustomCommand;
+import org.apache.pulsar.admin.cli.extensions.CustomCommandFactory;
+import org.apache.pulsar.admin.cli.extensions.CustomCommandGroup;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CommandFactory implements CustomCommandFactory {
+
+    @Override
+    public List<CustomCommandGroup> commandGroups(CommandExecutionContext context) {
+        return Arrays.asList(new CDCCommandGroup());
+    }
+
+    private static class CDCCommandGroup implements CustomCommandGroup {
+        @Override
+        public String name() {
+            return "cassandra-cdc";
+        }
+
+        @Override
+        public String description() {
+            return "Cassandra CDC commands";
+        }
+
+        @Override
+        public List<CustomCommand> commands(CommandExecutionContext context) {
+            return Arrays.asList(
+                    new BackfillCommand());
+        }
+    }
+}

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillBulkLoader.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillBulkLoader.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.dsbulk;
+
+import com.datastax.oss.dsbulk.runner.CleanupThread;
+import com.datastax.oss.dsbulk.runner.DataStaxBulkLoader;
+import com.datastax.oss.dsbulk.runner.ErrorHandler;
+import com.datastax.oss.dsbulk.runner.ExitStatus;
+import com.datastax.oss.dsbulk.runner.WorkflowThread;
+import com.datastax.oss.dsbulk.runner.cli.CommandLineParser;
+import com.datastax.oss.dsbulk.runner.cli.GlobalHelpRequestException;
+import com.datastax.oss.dsbulk.runner.cli.ParsedCommandLine;
+import com.datastax.oss.dsbulk.runner.cli.SectionHelpRequestException;
+import com.datastax.oss.dsbulk.runner.cli.VersionRequestException;
+import com.datastax.oss.dsbulk.runner.help.HelpEmitter;
+import com.datastax.oss.dsbulk.workflow.api.Workflow;
+import com.datastax.oss.dsbulk.workflow.api.utils.WorkflowUtils;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigResolveOptions;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+
+/**
+ * A class loader aware version of {@link DataStaxBulkLoader}.
+ */
+public class BackfillBulkLoader extends DataStaxBulkLoader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackfillBulkLoader.class);
+
+    private final String[] args;
+    private final ClassLoader configClassLoader;
+
+    public BackfillBulkLoader(ClassLoader configClassLoader, String... args) {
+        super(args);
+        this.args = args;
+        this.configClassLoader = configClassLoader;
+    }
+
+    @NonNull
+    public ExitStatus run() {
+        Workflow workflow = null;
+
+        try {
+            BackfillBulkLoaderCommandLineParser parser = new BackfillBulkLoaderCommandLineParser(configClassLoader, this.args);
+            BackfillParsedCommandLine result = parser.parse();
+            Config config = result.getConfig();
+            //shortcut the the: workflow = result.getWorkflowProvider().newWorkflow(config);
+            workflow = new BackfillUnloadWorkflow(configClassLoader, config);
+            WorkflowThread workflowThread = new WorkflowThread(workflow);
+            Runtime.getRuntime().addShutdownHook(new CleanupThread(workflow, workflowThread));
+            workflowThread.start();
+            workflowThread.join();
+            return workflowThread.getExitStatus();
+        } catch (BackfillGlobalHelpRequestException var7) {
+            HelpEmitter.emitGlobalHelp(var7.getConnectorName());
+            return ExitStatus.STATUS_OK;
+        } catch (SectionHelpRequestException var8) {
+            SectionHelpRequestException e = var8;
+
+            try {
+                HelpEmitter.emitSectionHelp(e.getSectionName(), e.getConnectorName());
+                return ExitStatus.STATUS_OK;
+            } catch (Exception var6) {
+                LOGGER.error(var6.getMessage(), var6);
+                return ExitStatus.STATUS_CRASHED;
+            }
+        } catch (VersionRequestException var9) {
+            PrintWriter pw = new PrintWriter(new BufferedWriter(new OutputStreamWriter(System.out, Charset.defaultCharset())));
+            pw.println(WorkflowUtils.getBulkLoaderNameAndVersion());
+            pw.flush();
+            return ExitStatus.STATUS_OK;
+        } catch (Throwable var10) {
+            return ErrorHandler.handleUnexpectedError(workflow, var10);
+        }
+    }
+}

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillBulkLoaderCommandLineParser.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillBulkLoaderCommandLineParser.java
@@ -1,0 +1,399 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.dsbulk;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.BiMap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import com.datastax.oss.dsbulk.config.ConfigUtils;
+import com.datastax.oss.dsbulk.config.shortcuts.ShortcutsFactory;
+import com.datastax.oss.dsbulk.io.IOUtils;
+import com.datastax.oss.dsbulk.runner.cli.AnsiConfigurator;
+import com.datastax.oss.dsbulk.runner.cli.GlobalHelpRequestException;
+import com.datastax.oss.dsbulk.runner.cli.ParseException;
+import com.datastax.oss.dsbulk.runner.cli.ParsedCommandLine;
+import com.datastax.oss.dsbulk.runner.cli.SectionHelpRequestException;
+import com.datastax.oss.dsbulk.runner.cli.VersionRequestException;
+import com.datastax.oss.dsbulk.runner.utils.StringUtils;
+import com.datastax.oss.dsbulk.workflow.api.WorkflowProvider;
+import com.datastax.oss.dsbulk.workflow.api.config.ConfigPostProcessor;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigSyntax;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+/**
+ * a class loader aware version of {@link com.datastax.oss.dsbulk.runner.cli.CommandLineParser}.
+ */
+public class BackfillBulkLoaderCommandLineParser {
+    private static final ConfigParseOptions COMMAND_LINE_ARGUMENTS;
+    private static final Set<String> COMMON_DRIVER_LIST_TYPE_SETTINGS;
+    private final List<String> args;
+
+    public final ClassLoader configClassLoader;
+
+    public BackfillBulkLoaderCommandLineParser(ClassLoader configClassLoader, String... args) {
+        this.args = Lists.newArrayList(args);
+        this.configClassLoader = configClassLoader;
+    }
+
+    public BackfillParsedCommandLine parse() throws ParseException, BackfillGlobalHelpRequestException, SectionHelpRequestException, VersionRequestException {
+        if (this.args.isEmpty()) {
+            throw new BackfillGlobalHelpRequestException();
+        } else {
+            this.checkVersionRequest();
+            AnsiConfigurator.configureAnsi(this.args);
+            Path applicationPath = this.resolveApplicationPath();
+            String connectorName = this.resolveConnectorName();
+            this.checkHelpRequest(connectorName);
+            ConfigFactory.invalidateCaches();
+            Config referenceConfig = BackfillConfigUtil.createReferenceConfig(configClassLoader);
+            Config applicationConfig = BackfillConfigUtil.createApplicationConfig(applicationPath, configClassLoader);
+            BiMap<String, String> shortcuts = ShortcutsFactory.createShortcutsMap(referenceConfig, connectorName == null ? "csv" : connectorName);
+            WorkflowProvider workflowProvider = this.resolveWorkflowType();
+            Config finalConfig = this.parseArguments(referenceConfig, applicationConfig, shortcuts).resolve();
+            finalConfig = this.postProcess(finalConfig);
+            return new BackfillParsedCommandLine(workflowProvider, finalConfig);
+        }
+    }
+
+    @Nullable
+    private Path resolveApplicationPath() throws ParseException {
+        Iterator<String> iterator = this.args.iterator();
+
+        String arg;
+        do {
+            if (!iterator.hasNext()) {
+                return null;
+            }
+
+            arg = (String)iterator.next();
+        } while(!arg.equals("-f"));
+
+        if (iterator.hasNext()) {
+            iterator.remove();
+            Path applicationPath = ConfigUtils.resolvePath((String)iterator.next());
+            iterator.remove();
+            IOUtils.assertAccessibleFile(applicationPath, "Application file");
+            return applicationPath;
+        } else {
+            throw new ParseException("Expecting application configuration path after -f");
+        }
+    }
+
+    @Nullable
+    private String resolveConnectorName() throws ParseException {
+        Iterator<String> iterator = this.args.iterator();
+
+        String arg;
+        do {
+            if (!iterator.hasNext()) {
+                return null;
+            }
+
+            arg = (String)iterator.next();
+        } while(!arg.equals("-c") && !arg.equals("--connector.name") && !arg.equals("--dsbulk.connector.name"));
+
+        if (iterator.hasNext()) {
+            return (String)iterator.next();
+        } else {
+            throw new ParseException("Expecting connector name after " + arg);
+        }
+    }
+
+    private void checkVersionRequest() throws VersionRequestException {
+        if (!this.args.isEmpty() && ("-v".equals(this.args.get(0)) || "--version".equals(this.args.get(0)))) {
+            throw new VersionRequestException();
+        }
+    }
+
+    private void checkHelpRequest(@Nullable String connectorName) throws ParseException, SectionHelpRequestException {
+        ListIterator<String> it = this.args.listIterator();
+
+        for(boolean firstArg = true; this.skipConnector(it); firstArg = false) {
+            String arg = (String)it.next();
+            boolean helpAsCommand = "help".equals(arg) && firstArg;
+            boolean helpAsLongOption = "--help".equals(arg);
+            if (helpAsCommand || helpAsLongOption) {
+                if (this.skipConnector(it)) {
+                    String sectionName = this.sanitizeSectionName((String)it.next());
+                    throw new SectionHelpRequestException(sectionName, connectorName);
+                } else {
+                    throw new ParseException("Expecting section name after " + arg);
+                }
+            }
+        }
+
+    }
+
+    private boolean skipConnector(ListIterator<String> it) {
+        if (it.hasNext()) {
+            String arg = (String)it.next();
+            if (!arg.equals("-c") && !arg.equals("--connector.name") && !arg.equals("--dsbulk.connector.name")) {
+                it.previous();
+            } else {
+                it.next();
+            }
+        }
+
+        return it.hasNext();
+    }
+
+    @NonNull
+    private String sanitizeSectionName(@NonNull String sectionName) {
+        if (sectionName.startsWith("driver")) {
+            sectionName = sectionName.replaceFirst("driver", "datastax-java-driver");
+        } else if (!sectionName.startsWith("datastax-java-driver") && !sectionName.startsWith("dsbulk")) {
+            sectionName = "dsbulk." + sectionName;
+        }
+
+        return sectionName;
+    }
+
+    @NonNull
+    private WorkflowProvider resolveWorkflowType() throws ParseException {
+        System.out.println("this.getAvailableCommands(): " + this.getAvailableCommands());
+        System.out.println("args: " + args);
+        if (!this.args.isEmpty()) {
+            String workflowTypeStr = (String)this.args.remove(0);
+            ServiceLoader<WorkflowProvider> loader = ServiceLoader.load(WorkflowProvider.class, configClassLoader);
+            Iterator var3 = loader.iterator();
+
+            while(var3.hasNext()) {
+                WorkflowProvider workflowProvider = (WorkflowProvider)var3.next();
+                if (workflowProvider.getTitle().equals(workflowTypeStr.toLowerCase())) {
+                    return workflowProvider;
+                }
+            }
+        }
+
+        throw new ParseException(String.format("First argument must be subcommand \"%s\", or \"help\"", this.getAvailableCommands()));
+    }
+
+    @NonNull
+    private Config postProcess(Config config) {
+        ServiceLoader<ConfigPostProcessor> loader = ServiceLoader.load(ConfigPostProcessor.class, configClassLoader);
+
+        ConfigPostProcessor processor;
+        for(Iterator var3 = loader.iterator(); var3.hasNext(); config = processor.postProcess(config)) {
+            processor = (ConfigPostProcessor)var3.next();
+        }
+
+        return config;
+    }
+
+    @NonNull
+    private String getAvailableCommands() {
+        // Use the classloader that loaded the Config class to load the WorkflowProvider implementations.
+        ServiceLoader<WorkflowProvider> loader = ServiceLoader.load(WorkflowProvider.class, configClassLoader);
+        List<String> commands = new ArrayList<>();
+        for (WorkflowProvider workflowProvider : loader) {
+            commands.add(workflowProvider.getTitle().toLowerCase());
+        }
+        return String.join("\", \"", commands);
+    }
+
+    @NonNull
+    private Config parseArguments(
+            Config referenceConfig, Config currentConfig, Map<String, String> shortcuts)
+            throws ParseException {
+        Iterator<String> iterator = args.iterator();
+        int argumentIndex = 0;
+        while (iterator.hasNext()) {
+            String arg = iterator.next();
+            argumentIndex++;
+            try {
+                String optionName = null;
+                String optionValue = null;
+                boolean wasLongOptionWithValue = false;
+                try {
+                    if (arg.startsWith("--")) {
+                        // First, try long option in the form : --key=value; this is not the recommended
+                        // way to input long options for dsbulk, but it has been supported since the
+                        // beginning. Parse the option using TypeSafe Config since it has to be valid.
+                        // We will sanitize the parsed value after.
+                        Config config = ConfigFactory.parseString(arg.substring(2));
+                        Map.Entry<String, ConfigValue> entry = config.entrySet().iterator().next();
+                        optionName = longNameToOptionName(entry.getKey(), referenceConfig);
+                        optionValue = entry.getValue().unwrapped().toString();
+                        wasLongOptionWithValue = true;
+                    }
+                } catch (ConfigException.Parse ignored) {
+                    // could not parse option, assume it wasn't a long option with value and fall through
+                }
+                if (!wasLongOptionWithValue) {
+                    // Now try long or short option :
+                    // --long.option.name value
+                    // -shortcut value
+                    optionName = parseLongOrShortOptionName(arg, shortcuts, referenceConfig);
+                    if (iterator.hasNext()) {
+                        // there must be at least one remaining argument containing the option value
+                        optionValue = iterator.next();
+                        argumentIndex++;
+                    } else {
+                        throw new ParseException("Expecting value after: " + arg);
+                    }
+                }
+                ConfigValueType optionType = getOptionType(optionName, referenceConfig);
+                if (optionType == ConfigValueType.OBJECT) {
+                    // the argument we are about to parse is a map (object), we want it to replace the
+                    // default value, not to be merged with it, so remove the path from the application
+                    // config.
+                    currentConfig = currentConfig.withoutPath(optionName);
+                }
+                String sanitizedOptionValue = sanitizeValue(optionValue, optionType);
+                // Pre-validate that optionName and sanitizedOptionValue are syntactically valid, throw
+                // immediately if something is not right to get a clear error message specifying the
+                // incriminated argument. This won't validate if the value is semantically correct (i.e.
+                // if value is of expected type): semantic validation is expected to occur later on in any
+                // of the *Settings classes.
+                try {
+                    // A hack to make the origin description contain the label "Command line argument"
+                    // followed by the line number, which corresponds to each argument index.
+                    String paddingBeforeOptionName =
+                            StringUtils.nCopies("\n", argumentIndex - (wasLongOptionWithValue ? 0 : 1));
+                    String paddingBeforeOptionValue = wasLongOptionWithValue ? "" : "\n";
+                    currentConfig =
+                            ConfigFactory.parseString(
+                                            paddingBeforeOptionName
+                                                    + optionName
+                                                    + '='
+                                                    + paddingBeforeOptionValue
+                                                    + sanitizedOptionValue,
+                                            COMMAND_LINE_ARGUMENTS)
+                                    .withFallback(currentConfig);
+                } catch (ConfigException e) {
+                    IllegalArgumentException cause = ConfigUtils.convertConfigException(e, "");
+                    if (optionType == null) {
+                        throw new ParseException(
+                                String.format("Invalid value for %s: '%s'", optionName, optionValue), cause);
+                    } else {
+                        throw new ParseException(
+                                String.format(
+                                        "Invalid value for %s, expecting %s, got: '%s'",
+                                        optionName, optionType, optionValue),
+                                cause);
+                    }
+                }
+            } catch (RuntimeException e) {
+                throw new ParseException("Could not parse argument: " + arg, e);
+            }
+        }
+        return currentConfig;
+    }
+
+    @Nullable
+    private ConfigValueType getOptionType(String path, Config referenceConfig) {
+        if (COMMON_DRIVER_LIST_TYPE_SETTINGS.contains(path)) {
+            return ConfigValueType.LIST;
+        } else {
+            ConfigValueType type = null;
+
+            try {
+                type = ConfigUtils.getValueType(referenceConfig, path);
+            } catch (ConfigException.Missing var5) {
+            }
+
+            return type;
+        }
+    }
+
+    @NonNull
+    private String parseLongOrShortOptionName(String arg, Map<String, String> shortcuts, Config referenceConfig) throws ParseException {
+        String optionName;
+        String shortcut;
+        if (arg.startsWith("--") && arg.length() > 2) {
+            shortcut = arg.substring(2);
+            optionName = this.longNameToOptionName(shortcut, referenceConfig);
+        } else {
+            if (!arg.startsWith("-") || arg.length() <= 1) {
+                throw new ParseException(String.format("Expecting long or short option, got: '%s'", arg));
+            }
+
+            shortcut = arg.substring(1);
+            optionName = this.shortcutToOptionName(arg, shortcut, shortcuts);
+        }
+
+        return optionName;
+    }
+
+    @NonNull
+    private String longNameToOptionName(String longName, Config referenceConfig) {
+        String optionName;
+        if (longName.startsWith("dsbulk.")) {
+            optionName = longName;
+        } else if (longName.startsWith("datastax-java-driver.")) {
+            optionName = longName;
+        } else if (longName.startsWith("driver.")) {
+            if (this.isDeprecatedDriverSetting(referenceConfig, longName)) {
+                optionName = "dsbulk." + longName;
+            } else {
+                optionName = longName.replaceFirst("driver\\.", "datastax-java-driver.");
+            }
+        } else {
+            optionName = "dsbulk." + longName;
+        }
+
+        return optionName;
+    }
+
+    @NonNull
+    private String shortcutToOptionName(String arg, String shortcut, Map<String, String> shortcuts) throws ParseException {
+        if (!shortcuts.containsKey(shortcut)) {
+            throw new ParseException("Unknown short option: " + arg);
+        } else {
+            return (String)shortcuts.get(shortcut);
+        }
+    }
+
+    private boolean isDeprecatedDriverSetting(Config referenceConfig, String settingName) {
+        return referenceConfig.getConfig("dsbulk").hasPathOrNull(settingName);
+    }
+
+    @NonNull
+    private String sanitizeValue(String optionValue, ConfigValueType optionType) {
+        String formatted = optionValue;
+        if (optionType == ConfigValueType.STRING) {
+            formatted = StringUtils.ensureQuoted(optionValue);
+        } else if (optionType == ConfigValueType.LIST) {
+            formatted = StringUtils.ensureBrackets(optionValue);
+        } else if (optionType == ConfigValueType.OBJECT) {
+            formatted = StringUtils.ensureBraces(optionValue);
+        }
+
+        return formatted;
+    }
+
+    static {
+        COMMAND_LINE_ARGUMENTS = ConfigParseOptions.defaults().setOriginDescription("command line argument").setSyntax(ConfigSyntax.CONF);
+        COMMON_DRIVER_LIST_TYPE_SETTINGS = ImmutableSet.of("datastax-java-driver.basic.contact-points", "datastax-java-driver.advanced.ssl-engine-factory.cipher-suites", "datastax-java-driver.advanced.metrics.session.enabled", "datastax-java-driver.advanced.metrics.node.enabled", "datastax-java-driver.advanced.metadata.schema.refreshed-keyspaces");
+    }
+}
+

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillConfigUtil.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillConfigUtil.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.dsbulk;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import java.nio.file.Path;
+
+/**
+ * Class loader aware version of {@link com.datastax.oss.dsbulk.config.ConfigUtils}.
+ */
+public class BackfillConfigUtil {
+
+    @NonNull
+    public static Config createReferenceConfig(ClassLoader classLoader) {
+        return ConfigFactory.parseResourcesAnySyntax("dsbulk-reference",
+                ConfigParseOptions.defaults().setClassLoader(classLoader))
+                .withFallback(ConfigFactory.parseResourcesAnySyntax("driver-reference",
+                        ConfigParseOptions.defaults().setClassLoader(classLoader)))
+                .withFallback(ConfigFactory.defaultReferenceUnresolved());
+    }
+
+    @NonNull
+    public static Config createApplicationConfig(@Nullable Path appConfigPath, ClassLoader classLoader) {
+        try {
+            if (appConfigPath != null) {
+                System.setProperty("config.file", appConfigPath.toString());
+            }
+
+            Config referenceConfig = createReferenceConfig(classLoader);
+            return ConfigFactory.defaultOverrides().withFallback(ConfigFactory.defaultApplication()).withFallback(referenceConfig);
+        } catch (ConfigException.Parse var2) {
+            throw new IllegalArgumentException(String.format("Error parsing configuration file %s at line %s. Please make sure its format is compliant with HOCON syntax. If you are using \\ (backslash) to define a path, escape it with \\\\ or use / (forward slash) instead.", var2.origin().filename(), var2.origin().lineNumber()), var2);
+        }
+    }
+}

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillGlobalHelpRequestException.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillGlobalHelpRequestException.java
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 
-package com.datastax.oss.cdc.backfill.factory;
+package com.datastax.oss.cdc.backfill.dsbulk;
 
-import com.datastax.oss.cdc.backfill.dsbulk.BackfillBulkLoader;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
-public class DsBulkFactory {
-    public BackfillBulkLoader newLoader(String[] args) {
-        ClassLoader configClassLoader = DsBulkFactory.class.getClassLoader();
-        return new BackfillBulkLoader(configClassLoader, args);
+public class BackfillGlobalHelpRequestException extends Exception {
+    private final String connectorName;
+
+    BackfillGlobalHelpRequestException() {
+        this((String)null);
+    }
+
+    BackfillGlobalHelpRequestException(@Nullable String connectorName) {
+        this.connectorName = connectorName;
+    }
+
+    @Nullable
+    public String getConnectorName() {
+        return this.connectorName;
     }
 }

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillParsedCommandLine.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillParsedCommandLine.java
@@ -14,13 +14,25 @@
  * limitations under the License.
  */
 
-package com.datastax.oss.cdc.backfill.factory;
+package com.datastax.oss.cdc.backfill.dsbulk;
 
-import com.datastax.oss.cdc.backfill.dsbulk.BackfillBulkLoader;
+import com.datastax.oss.dsbulk.workflow.api.WorkflowProvider;
+import com.typesafe.config.Config;
 
-public class DsBulkFactory {
-    public BackfillBulkLoader newLoader(String[] args) {
-        ClassLoader configClassLoader = DsBulkFactory.class.getClassLoader();
-        return new BackfillBulkLoader(configClassLoader, args);
+public class BackfillParsedCommandLine {
+    private final WorkflowProvider workflowProvider;
+    private final Config config;
+
+    BackfillParsedCommandLine(WorkflowProvider workflowProvider, Config config) {
+        this.workflowProvider = workflowProvider;
+        this.config = config;
+    }
+
+    public WorkflowProvider getWorkflowProvider() {
+        return this.workflowProvider;
+    }
+
+    public Config getConfig() {
+        return this.config;
     }
 }

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillUnloadWorkflow.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/BackfillUnloadWorkflow.java
@@ -1,0 +1,381 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.dsbulk;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.shaded.guava.common.base.Stopwatch;
+import com.datastax.oss.dsbulk.codecs.api.ConvertingCodecFactory;
+import com.datastax.oss.dsbulk.connectors.api.CommonConnectorFeature;
+import com.datastax.oss.dsbulk.connectors.api.Connector;
+import com.datastax.oss.dsbulk.connectors.api.Record;
+import com.datastax.oss.dsbulk.connectors.api.RecordMetadata;
+import com.datastax.oss.dsbulk.executor.api.reader.BulkReader;
+import com.datastax.oss.dsbulk.executor.api.result.ReadResult;
+import com.datastax.oss.dsbulk.workflow.api.Workflow;
+import com.datastax.oss.dsbulk.workflow.api.utils.DurationUtils;
+import com.datastax.oss.dsbulk.workflow.commons.log.DefaultRangeReadResource;
+import com.datastax.oss.dsbulk.workflow.commons.log.LogManager;
+import com.datastax.oss.dsbulk.workflow.commons.log.RangeReadResource;
+import com.datastax.oss.dsbulk.workflow.commons.metrics.MetricsManager;
+import com.datastax.oss.dsbulk.workflow.commons.schema.ReadResultMapper;
+import com.datastax.oss.dsbulk.workflow.commons.settings.CodecSettings;
+import com.datastax.oss.dsbulk.workflow.commons.settings.ConnectorSettings;
+import com.datastax.oss.dsbulk.workflow.commons.settings.DriverSettings;
+import com.datastax.oss.dsbulk.workflow.commons.settings.EngineSettings;
+import com.datastax.oss.dsbulk.workflow.commons.settings.ExecutorSettings;
+import com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings;
+import com.datastax.oss.dsbulk.workflow.commons.settings.MonitoringSettings;
+import com.datastax.oss.dsbulk.workflow.commons.settings.SchemaGenerationStrategy;
+import com.datastax.oss.dsbulk.workflow.commons.settings.SchemaSettings;
+import com.datastax.oss.dsbulk.workflow.commons.settings.SettingsManager;
+import com.datastax.oss.dsbulk.workflow.commons.statement.RangeReadBoundStatement;
+import com.datastax.oss.dsbulk.workflow.commons.utils.CloseableUtils;
+import com.datastax.oss.dsbulk.workflow.commons.utils.ClusterInformationUtils;
+import com.typesafe.config.Config;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/** The main class for unload workflows. */
+public class BackfillUnloadWorkflow implements Workflow {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(com.datastax.oss.dsbulk.workflow.unload.UnloadWorkflow.class);
+
+    private final SettingsManager settingsManager;
+    private final ClassLoader configClassLoader;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private String executionId;
+    private Connector connector;
+    private Set<Scheduler> schedulers;
+    private ReadResultMapper readResultMapper;
+    private MetricsManager metricsManager;
+    private LogManager logManager;
+    private CqlSession session;
+    private BulkReader executor;
+    private List<RangeReadBoundStatement> readStatements;
+    private Function<Publisher<Record>, Publisher<Record>> writer;
+    private Function<Flux<ReadResult>, Flux<ReadResult>> totalItemsMonitor;
+    private Function<Flux<Record>, Flux<Record>> failedRecordsMonitor;
+    private Function<Flux<ReadResult>, Flux<ReadResult>> failedReadResultsMonitor;
+    private Function<Flux<Record>, Flux<Record>> failedRecordsHandler;
+    private Function<Flux<ReadResult>, Flux<ReadResult>> totalItemsCounter;
+    private Function<Flux<ReadResult>, Flux<ReadResult>> failedReadsHandler;
+    private Function<Flux<ReadResult>, Flux<ReadResult>> queryWarningsHandler;
+    private Function<Flux<Record>, Flux<Record>> unmappableRecordsHandler;
+    private Function<Flux<Record>, Flux<Void>> successfulRecordsHandler;
+    private Function<Flux<RangeReadResource>, Flux<Flux<ReadResult>>> checkpointHandler;
+    private Function<Flux<Void>, Flux<Void>> terminationHandler;
+    private int readConcurrency;
+    private int numCores;
+    private int writeConcurrency;
+
+    BackfillUnloadWorkflow(ClassLoader configClassLoader, Config config) {
+        this.configClassLoader = configClassLoader;
+        this.settingsManager = new SettingsManager(config);
+    }
+
+    @Override
+    public void init() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(configClassLoader);
+        settingsManager.init("UNLOAD", false, SchemaGenerationStrategy.READ_AND_MAP);
+        executionId = settingsManager.getExecutionId();
+        LogSettings logSettings = settingsManager.getLogSettings();
+        DriverSettings driverSettings = settingsManager.getDriverSettings();
+        ConnectorSettings connectorSettings = settingsManager.getConnectorSettings();
+        SchemaSettings schemaSettings = settingsManager.getSchemaSettings();
+        ExecutorSettings executorSettings = settingsManager.getExecutorSettings();
+        CodecSettings codecSettings = settingsManager.getCodecSettings();
+        MonitoringSettings monitoringSettings = settingsManager.getMonitoringSettings();
+        EngineSettings engineSettings = settingsManager.getEngineSettings();
+        engineSettings.init();
+        // First verify that dry-run is off; that's unsupported for unload.
+        if (engineSettings.isDryRun()) {
+            throw new IllegalArgumentException("Dry-run is not supported for unload");
+        }
+        logSettings.init();
+        connectorSettings.init(false);
+        connector = connectorSettings.getConnector();
+        connector.init();
+        driverSettings.init(false);
+        logSettings.logEffectiveSettings(
+                settingsManager.getEffectiveBulkLoaderConfig(), driverSettings.getDriverConfig());
+        codecSettings.init();
+        monitoringSettings.init();
+        executorSettings.init();
+        ConvertingCodecFactory codecFactory =
+                codecSettings.createCodecFactory(
+                        schemaSettings.isAllowExtraFields(), schemaSettings.isAllowMissingFields());
+        session =
+                driverSettings.newSession(
+                        executionId, codecFactory.getCodecRegistry(), monitoringSettings.getRegistry());
+        ClusterInformationUtils.printDebugInfoAboutCluster(session);
+        schemaSettings.init(
+                session,
+                codecFactory,
+                connector.supports(CommonConnectorFeature.INDEXED_RECORDS),
+                connector.supports(CommonConnectorFeature.MAPPED_RECORDS));
+        logManager = logSettings.newLogManager(session);
+        logManager.init();
+        if (executorSettings.isTrackingBytes()) {
+            monitoringSettings.forceTrackBytes();
+        }
+        metricsManager =
+                monitoringSettings.newMetricsManager(
+                        false,
+                        false,
+                        logManager.getOperationDirectory(),
+                        logSettings.getVerbosity(),
+                        session.getContext().getProtocolVersion(),
+                        session.getContext().getCodecRegistry(),
+                        schemaSettings.getRowType());
+        metricsManager.init(logManager.getTotalItems(), logManager.getTotalErrors());
+        RecordMetadata recordMetadata = connector.getRecordMetadata();
+        readResultMapper =
+                schemaSettings.createReadResultMapper(session, recordMetadata, logSettings.isSources());
+        readStatements = schemaSettings.createReadStatements(session);
+        executor =
+                executorSettings.newReadExecutor(
+                        session, metricsManager.getExecutionListener(), schemaSettings.isSearchQuery());
+        closed.set(false);
+        writer = connector.write();
+        totalItemsMonitor = metricsManager.newTotalItemsMonitor();
+        failedRecordsMonitor = metricsManager.newFailedRecordsMonitor();
+        failedReadResultsMonitor = metricsManager.newFailedResultsMonitor();
+        failedRecordsHandler = logManager.newFailedRecordsHandler();
+        totalItemsCounter = logManager.newTotalItemsCounter();
+        failedReadsHandler = logManager.newFailedReadsHandler();
+        queryWarningsHandler = logManager.newQueryWarningsHandler();
+        unmappableRecordsHandler = logManager.newUnmappableRecordsHandler();
+        successfulRecordsHandler = logManager.newSuccessfulRecordsHandler();
+        checkpointHandler = logManager.newRangeReadCheckpointHandler();
+        terminationHandler = logManager.newTerminationHandler();
+        numCores = Runtime.getRuntime().availableProcessors();
+        if (connector.writeConcurrency() < 1) {
+            throw new IllegalArgumentException(
+                    "Invalid write concurrency: " + connector.writeConcurrency());
+        }
+        writeConcurrency = connector.writeConcurrency();
+        LOGGER.debug("Using write concurrency: {}", writeConcurrency);
+        readConcurrency =
+                Math.min(
+                        readStatements.size(),
+                        // Most connectors have a default of numCores/2 for writeConcurrency;
+                        // a good readConcurrency is then numCores.
+                        engineSettings.getMaxConcurrentQueries().orElse(numCores));
+        LOGGER.debug(
+                "Using read concurrency: {} (user-supplied: {})",
+                readConcurrency,
+                engineSettings.getMaxConcurrentQueries().isPresent());
+        schedulers = new HashSet<>();
+    }
+
+    @Override
+    public boolean execute() {
+        LOGGER.debug("{} started.", this);
+        metricsManager.start();
+        Flux<Void> flux;
+        if (writeConcurrency == 1) {
+            flux = oneWriter();
+        } else if (writeConcurrency < numCores / 2 || readConcurrency < numCores / 2) {
+            flux = fewWriters();
+        } else {
+            flux = manyWriters();
+        }
+        Stopwatch timer = Stopwatch.createStarted();
+        flux.transform(terminationHandler).blockLast();
+        timer.stop();
+        int totalErrors = logManager.getTotalErrors();
+        metricsManager.stop(timer.elapsed(), totalErrors == 0);
+        Duration elapsed = DurationUtils.round(timer.elapsed(), TimeUnit.SECONDS);
+        String elapsedStr =
+                elapsed.isZero() ? "less than one second" : DurationUtils.formatDuration(elapsed);
+        if (totalErrors == 0) {
+            LOGGER.info("{} completed successfully in {}.", this, elapsedStr);
+        } else {
+            LOGGER.warn(
+                    "{} completed with {} errors in {}.",
+                    this,
+                    String.format("%,d", totalErrors),
+                    elapsedStr);
+        }
+        return totalErrors == 0;
+    }
+
+    private Flux<Void> oneWriter() {
+        int numThreads = Math.min(numCores * 2, readConcurrency);
+        Scheduler scheduler =
+                numThreads == 1
+                        ? Schedulers.immediate()
+                        : Schedulers.newParallel(numThreads, new DefaultThreadFactory("workflow"));
+        schedulers.add(scheduler);
+        return Flux.fromIterable(readStatements)
+                .map(stmt -> (RangeReadResource) new DefaultRangeReadResource(stmt, executor))
+                .transform(checkpointHandler)
+                .flatMap(
+                        results ->
+                                results
+                                        .publishOn(scheduler, 500)
+                                        .transform(queryWarningsHandler)
+                                        .transform(totalItemsMonitor)
+                                        .transform(totalItemsCounter)
+                                        .transform(failedReadResultsMonitor)
+                                        .transform(failedReadsHandler)
+                                        .map(readResultMapper::map)
+                                        .transform(failedRecordsMonitor)
+                                        .transform(unmappableRecordsHandler),
+                        readConcurrency,
+                        500)
+                .transform(writer)
+                .transform(failedRecordsMonitor)
+                .transform(failedRecordsHandler)
+                .transform(successfulRecordsHandler);
+    }
+
+    private Flux<Void> fewWriters() {
+        // writeConcurrency cannot be 1 here, but readConcurrency can
+        int numThreadsForReads = Math.min(numCores, readConcurrency);
+        Scheduler schedulerForReads =
+                numThreadsForReads == 1
+                        ? Schedulers.immediate()
+                        : Schedulers.newParallel(numThreadsForReads, new DefaultThreadFactory("workflow-read"));
+        int numThreadsForWrites = Math.min(numCores, writeConcurrency);
+        Scheduler schedulerForWrites =
+                Schedulers.newParallel(numThreadsForWrites, new DefaultThreadFactory("workflow-write"));
+        schedulers.add(schedulerForReads);
+        schedulers.add(schedulerForWrites);
+        return Flux.fromIterable(readStatements)
+                .map(stmt -> (RangeReadResource) new DefaultRangeReadResource(stmt, executor))
+                .transform(checkpointHandler)
+                .flatMap(
+                        results ->
+                                results
+                                        .publishOn(schedulerForReads, 500)
+                                        .transform(queryWarningsHandler)
+                                        .transform(totalItemsMonitor)
+                                        .transform(totalItemsCounter)
+                                        .transform(failedReadResultsMonitor)
+                                        .transform(failedReadsHandler)
+                                        .map(readResultMapper::map)
+                                        .transform(failedRecordsMonitor)
+                                        .transform(unmappableRecordsHandler),
+                        readConcurrency,
+                        500)
+                .parallel(writeConcurrency)
+                .runOn(schedulerForWrites)
+                .groups()
+                .flatMap(
+                        records ->
+                                records
+                                        .transform(writer)
+                                        .transform(failedRecordsMonitor)
+                                        .transform(failedRecordsHandler)
+                                        .transform(successfulRecordsHandler),
+                        writeConcurrency,
+                        500);
+    }
+
+    private Flux<Void> manyWriters() {
+        // writeConcurrency and readConcurrency are >= 0.5C here
+        int actualConcurrency = Math.min(readConcurrency, writeConcurrency);
+        int numThreads = Math.min(numCores * 2, actualConcurrency);
+        Scheduler scheduler = Schedulers.newParallel(numThreads, new DefaultThreadFactory("workflow"));
+        schedulers.add(scheduler);
+        return Flux.fromIterable(readStatements)
+                .map(stmt -> (RangeReadResource) new DefaultRangeReadResource(stmt, executor))
+                .transform(checkpointHandler)
+                .flatMap(
+                        results -> {
+                            Flux<Record> records =
+                                    results
+                                            .publishOn(scheduler, 500)
+                                            .transform(queryWarningsHandler)
+                                            .transform(totalItemsMonitor)
+                                            .transform(totalItemsCounter)
+                                            .transform(failedReadResultsMonitor)
+                                            .transform(failedReadsHandler)
+                                            .map(readResultMapper::map)
+                                            .transform(failedRecordsMonitor)
+                                            .transform(unmappableRecordsHandler);
+                            if (actualConcurrency == writeConcurrency) {
+                                records = records.transform(writer);
+                            } else {
+                                // If the actual concurrency is lesser than the connector's desired write
+                                // concurrency, we need to give the connector a chance to switch writers
+                                // frequently so that it can really redirect records to all the final destinations
+                                // (to that many files on disk for example). If the connector is correctly
+                                // implemented, each window will be redirected to a different destination
+                                // in a round-robin fashion.
+                                records = records.window(500).flatMap(window -> window.transform(writer), 1, 500);
+                            }
+                            return records
+                                    .transform(failedRecordsMonitor)
+                                    .transform(failedRecordsHandler)
+                                    .transform(successfulRecordsHandler);
+                        },
+                        actualConcurrency,
+                        500);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (closed.compareAndSet(false, true)) {
+            LOGGER.debug("{} closing.", this);
+            Exception e = CloseableUtils.closeQuietly(metricsManager, null);
+            e = CloseableUtils.closeQuietly(logManager, e);
+            e = CloseableUtils.closeQuietly(connector, e);
+            if (schedulers != null) {
+                for (Scheduler scheduler : schedulers) {
+                    e = CloseableUtils.closeQuietly(scheduler, e);
+                }
+            }
+            e = CloseableUtils.closeQuietly(executor, e);
+            e = CloseableUtils.closeQuietly(session, e);
+            if (metricsManager != null) {
+                metricsManager.reportFinalMetrics();
+            }
+            if (logManager != null) {
+                logManager.reportAvailableFiles();
+            }
+            LOGGER.debug("{} closed.", this);
+            if (e != null) {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (executionId == null) {
+            return "Operation";
+        } else {
+            return "Operation " + executionId;
+        }
+    }
+}

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/LogSettings.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/dsbulk/LogSettings.java
@@ -1,0 +1,476 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.cdc.backfill.dsbulk;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.filter.ThresholdFilter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.FileAppender;
+import ch.qos.logback.core.OutputStreamAppender;
+import ch.qos.logback.core.filter.Filter;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.driver.shaded.guava.common.base.Joiner;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.dsbulk.config.ConfigUtils;
+import com.datastax.oss.dsbulk.connectors.api.Record;
+import com.datastax.oss.dsbulk.format.row.RowFormatter;
+import com.datastax.oss.dsbulk.format.statement.StatementFormatVerbosity;
+import com.datastax.oss.dsbulk.format.statement.StatementFormatter;
+import com.datastax.oss.dsbulk.workflow.api.error.ErrorThreshold;
+import com.datastax.oss.dsbulk.workflow.api.log.OperationDirectory;
+import com.datastax.oss.dsbulk.workflow.api.log.OperationDirectoryResolver;
+import com.datastax.oss.dsbulk.workflow.api.utils.WorkflowUtils;
+import com.datastax.oss.dsbulk.workflow.commons.log.LogManager;
+import com.datastax.oss.dsbulk.workflow.commons.log.checkpoint.CheckpointManager;
+import com.datastax.oss.dsbulk.workflow.commons.log.checkpoint.ReplayStrategy;
+import com.datastax.oss.dsbulk.workflow.commons.statement.MappedBoundStatementPrinter;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigRenderOptions;
+import com.typesafe.config.ConfigValue;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+public class LogSettings {
+
+    public enum Verbosity {
+        quiet,
+        normal,
+        high,
+        max
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings.class);
+    private static final String CONSOLE_APPENDER = "CONSOLE";
+
+    private static final int MIN_SAMPLE = 100;
+
+    private static final String MAIN_LOG_FILE_APPENDER = "FILE";
+    private static final String MAIN_LOG_FILE_NAME = "operation.log";
+
+    /** The options for stack trace printing. */
+    public static final ImmutableList<String> STACK_TRACE_PRINTER_OPTIONS =
+            ImmutableList.of(
+                    // number of stack elements to print
+                    "10",
+                    // packages to exclude from stack traces
+                    "reactor.core",
+                    "com.datastax.oss.driver.shaded",
+                    "io.netty",
+                    "java.util.concurrent");
+
+    /**
+     * The layout pattern to use for the main log file.
+     *
+     * <p>Example of formatted message:
+     *
+     * <pre>
+     * 2018-03-09 14:41:02 ERROR Unload workflow engine execution UNLOAD_20180309-144101-093338 aborted: Invalid table
+     * com.datastax.driver.core.exceptions.SyntaxError: Invalid table
+     *     at com.datastax.driver.core.exceptions.SyntaxError.copy(SyntaxError.java:49)
+     * 	   ...
+     * </pre>
+     */
+    private static final String LAYOUT_PATTERN =
+            "%date{yyyy-MM-dd HH:mm:ss,UTC} %-5level %msg%n%ex{"
+                    + Joiner.on(',').join(STACK_TRACE_PRINTER_OPTIONS)
+                    + "}";
+
+    private static final String DEBUG_LAYOUT_PATTERN =
+            "%date{yyyy-MM-dd HH:mm:ss,UTC} %-5level %-15thread %-45logger{45} %msg%n";
+
+    private static final Comparator<Entry<String, ConfigValue>> BASIC_SETTINGS_FIRST =
+            Comparator.comparing(
+                    entry -> entry.getKey().replaceFirst("basic\\.", "0.").replaceFirst("advanced\\.", "1."));
+
+    private static final List<String> PATHS_TO_OBFUSCATE =
+            ImmutableList.of(
+                    "advanced.auth-provider.password",
+                    "advanced.ssl-engine-factory.truststore-password",
+                    "advanced.ssl-engine-factory.keystore-password");
+
+    // Path Constants
+    private static final String STMT = "stmt";
+    private static final String ROW = "row";
+    private static final String MAX_QUERY_STRING_LENGTH = STMT + '.' + "maxQueryStringLength";
+    private static final String MAX_BOUND_VALUE_LENGTH = STMT + '.' + "maxBoundValueLength";
+    private static final String MAX_BOUND_VALUES = STMT + '.' + "maxBoundValues";
+    private static final String MAX_INNER_STATEMENTS = STMT + '.' + "maxInnerStatements";
+    private static final String MAX_RESULT_SET_VALUE_LENGTH = ROW + '.' + "maxResultSetValueLength";
+    private static final String MAX_RESULT_SET_VALUES = ROW + '.' + "maxResultSetValues";
+    private static final String LEVEL = STMT + '.' + "level";
+    private static final String MAX_ERRORS = "maxErrors";
+    private static final String MAX_QUERY_WARNINGS = "maxQueryWarnings";
+    private static final String VERBOSITY = "verbosity";
+    private static final String SOURCES = "sources";
+
+    private final Config config;
+    private final String executionId;
+
+    private Path operationDirectory;
+    private int maxQueryStringLength;
+    private int maxBoundValueLength;
+    private int maxBoundValues;
+    private int maxResultSetValueLength;
+    private int maxResultSetValues;
+    private int maxInnerStatements;
+    private StatementFormatVerbosity level;
+    @VisibleForTesting ErrorThreshold errorThreshold;
+    @VisibleForTesting ErrorThreshold queryWarningsThreshold;
+    private com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings.Verbosity verbosity;
+    private boolean sources;
+    private boolean checkpointEnabled;
+    private ReplayStrategy checkpointReplayStrategy;
+    private CheckpointManager checkpointManager;
+
+    public LogSettings(Config config, String executionId) {
+        this.config = config;
+        this.executionId = executionId;
+    }
+
+    public void init() throws IOException {
+        try {
+            // Note: log.ansiMode is handled upstream by the runner
+            // com.datastax.oss.dsbulk.runner.cli.AnsiConfigurator
+            operationDirectory =
+                    new OperationDirectoryResolver(ConfigUtils.getPath(config, "directory"), executionId)
+                            .resolve();
+            OperationDirectory.setCurrentOperationDirectory(operationDirectory);
+            maxQueryStringLength = config.getInt(MAX_QUERY_STRING_LENGTH);
+            maxBoundValueLength = config.getInt(MAX_BOUND_VALUE_LENGTH);
+            maxBoundValues = config.getInt(MAX_BOUND_VALUES);
+            maxInnerStatements = config.getInt(MAX_INNER_STATEMENTS);
+            level = config.getEnum(StatementFormatVerbosity.class, LEVEL);
+            maxResultSetValueLength = config.getInt(MAX_RESULT_SET_VALUE_LENGTH);
+            maxResultSetValues = config.getInt(MAX_RESULT_SET_VALUES);
+            String maxErrorString = config.getString(MAX_ERRORS);
+            if (isPercent(maxErrorString)) {
+                float maxErrorsRatio = Float.parseFloat(maxErrorString.replaceAll("\\s*%", "")) / 100f;
+                validatePercentageRange(maxErrorsRatio);
+                errorThreshold = ErrorThreshold.forRatio(maxErrorsRatio, MIN_SAMPLE);
+            } else {
+                long maxErrors = config.getLong(MAX_ERRORS);
+                if (maxErrors < 0) {
+                    errorThreshold = ErrorThreshold.unlimited();
+                } else {
+                    errorThreshold = ErrorThreshold.forAbsoluteValue(maxErrors);
+                }
+            }
+            long maxQueryWarnings = config.getLong(MAX_QUERY_WARNINGS);
+            if (maxQueryWarnings < 0) {
+                queryWarningsThreshold = ErrorThreshold.unlimited();
+            } else {
+                queryWarningsThreshold = ErrorThreshold.forAbsoluteValue(maxQueryWarnings);
+            }
+            Path mainLogFile =
+                    operationDirectory.resolve(MAIN_LOG_FILE_NAME).normalize().toAbsolutePath();
+            createMainLogFileAppender(mainLogFile);
+            installJavaLoggingToSLF4JBridge();
+            verbosity = processVerbosityLevel();
+            switch (verbosity) {
+                case quiet:
+                    setVerbosityQuiet();
+                    break;
+                case high:
+                    setVerbosityHigh();
+                    break;
+                case max:
+                    setVerbosityMax();
+                    break;
+                default:
+                    setVerbosityNormal();
+                    break;
+            }
+            sources = config.getBoolean(SOURCES);
+            checkpointEnabled = config.getBoolean("checkpoint.enabled");
+            checkpointReplayStrategy = config.getEnum(ReplayStrategy.class, "checkpoint.replayStrategy");
+            if (config.hasPath("checkpoint.file")) {
+                Path path = ConfigUtils.getPath(config, "checkpoint.file");
+                try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+                    checkpointManager = CheckpointManager.parse(reader);
+                }
+                if (checkpointManager.isComplete(checkpointReplayStrategy)) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Nothing to replay using replay strategy %s in checkpoint file: %s.",
+                                    checkpointReplayStrategy, path));
+                }
+                LOGGER.warn("Replaying from checkpoint file: {}.", path);
+                LOGGER.warn(
+                        "Record metrics will reflect totals from the previous operation; other metrics won't be affected.");
+                LOGGER.warn(
+                        "Only errors and rejected records generated by the current operation will be reported in its log files.");
+            } else {
+                checkpointManager = new CheckpointManager();
+            }
+        } catch (ConfigException e) {
+            throw ConfigUtils.convertConfigException(e, "dsbulk.log");
+        }
+    }
+
+    public void logEffectiveSettings(Config dsbulkConfig, Config driverConfig) {
+        LOGGER.debug("{} starting.", WorkflowUtils.getBulkLoaderNameAndVersion());
+        // Initialize the following static fields: their initialization will print the driver
+        // coordinates to the console at INFO level, which is enough.
+        Objects.requireNonNull(Session.OSS_DRIVER_COORDINATES);
+        LOGGER.debug("Available processors: {}.", Runtime.getRuntime().availableProcessors());
+        LOGGER.info("Operation directory: {}", operationDirectory);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("DataStax Bulk Loader Effective settings:");
+            dumpConfig(dsbulkConfig.withoutPath("driver"), Entry.comparingByKey());
+            LOGGER.debug("DataStax Java Driver Effective settings:");
+            dumpConfig(driverConfig, BASIC_SETTINGS_FIRST);
+        }
+    }
+
+    private void dumpConfig(Config config, Comparator<Entry<String, ConfigValue>> comparator) {
+        Set<Entry<String, ConfigValue>> entries = new TreeSet<>(comparator);
+        entries.addAll(config.entrySet());
+        for (Entry<String, ConfigValue> entry : entries) {
+            String key = entry.getKey();
+            String value;
+            if (PATHS_TO_OBFUSCATE.contains(key)) {
+                value = "***************";
+            } else {
+                value = entry.getValue().render(ConfigRenderOptions.concise());
+            }
+            LOGGER.debug(String.format("- %s = %s", key, value));
+        }
+    }
+
+    public LogManager newLogManager(CqlSession session) {
+        StatementFormatter statementFormatter =
+                StatementFormatter.builder()
+                        .withMaxQueryStringLength(maxQueryStringLength)
+                        .withMaxBoundValueLength(maxBoundValueLength)
+                        .withMaxBoundValues(maxBoundValues)
+                        .withMaxInnerStatements(maxInnerStatements)
+                        .addStatementPrinters(new MappedBoundStatementPrinter())
+                        .build();
+        RowFormatter rowFormatter = new RowFormatter(maxResultSetValueLength, maxResultSetValues);
+        return new LogManager(
+                session,
+                operationDirectory,
+                errorThreshold,
+                queryWarningsThreshold,
+                statementFormatter,
+                level,
+                rowFormatter,
+                checkpointEnabled,
+                checkpointManager,
+                checkpointReplayStrategy);
+    }
+
+    @NonNull
+    public com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings.Verbosity getVerbosity() {
+        return verbosity;
+    }
+
+    /**
+     * Whether {@linkplain Record#getSource() record sources} should be retained in memory. When
+     * sources are retained, DSBulk is able to print record sources in debug files, for easier error
+     * diagnostic. When loading, it also enables DSBulk to create bad files for records that failed to
+     * be processed.
+     */
+    public boolean isSources() {
+        return sources;
+    }
+
+    @VisibleForTesting
+    public static void createMainLogFileAppender(Path mainLogFile) {
+        if (!(LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) instanceof ch.qos.logback.classic.Logger)) {
+            // This is workaround to avoid runtime errors when the backfill CLI is invoked as a pulsar admin extention
+            // where the logger type is of type org.apache.logging.slf4j.Log4jLogger
+            return;
+        }
+        ch.qos.logback.classic.Logger root =
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        LoggerContext lc = root.getLoggerContext();
+        PatternLayoutEncoder ple = new PatternLayoutEncoder();
+        ple.setPattern(LAYOUT_PATTERN);
+        ple.setContext(lc);
+        ple.setCharset(StandardCharsets.UTF_8);
+        ple.start();
+        FileAppender<ILoggingEvent> mainLogFileAppender = new FileAppender<>();
+        mainLogFileAppender.setName(MAIN_LOG_FILE_APPENDER);
+        mainLogFileAppender.setFile(mainLogFile.toFile().getAbsolutePath());
+        mainLogFileAppender.setEncoder(ple);
+        mainLogFileAppender.setContext(lc);
+        mainLogFileAppender.setAppend(false);
+        ThresholdFilter thresholdFilter = new ThresholdFilter();
+        thresholdFilter.setLevel("INFO");
+        thresholdFilter.start();
+        mainLogFileAppender.addFilter(thresholdFilter);
+        mainLogFileAppender.start();
+        root.addAppender(mainLogFileAppender);
+    }
+
+    private static void installJavaLoggingToSLF4JBridge() {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+    }
+
+    private com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings.Verbosity processVerbosityLevel() {
+        try {
+            int verbosity = config.getInt(VERBOSITY);
+            validateNumericVerbosity(verbosity);
+            return com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings.Verbosity.values()[verbosity];
+        } catch (ConfigException.WrongType e) {
+            return config.getEnum(com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings.Verbosity.class, VERBOSITY);
+        }
+    }
+
+    @VisibleForTesting
+    public static void setVerbosityQuiet() {
+        setAppenderThreshold(CONSOLE_APPENDER, "WARN");
+        setAppenderThreshold(MAIN_LOG_FILE_APPENDER, "WARN");
+        // raise log levels to WARN across the board
+        seLoggerThreshold("com.datastax.oss.dsbulk", Level.WARN);
+        seLoggerThreshold("com.datastax.oss.driver", Level.WARN);
+        seLoggerThreshold("com.datastax.dse.driver", Level.WARN);
+        seLoggerThreshold("io.netty", Level.WARN);
+        seLoggerThreshold("reactor.core", Level.WARN);
+    }
+
+    @VisibleForTesting
+    public static void setVerbosityHigh() {
+        setAppenderThreshold(CONSOLE_APPENDER, "DEBUG");
+        setAppenderThreshold(MAIN_LOG_FILE_APPENDER, "DEBUG");
+        // downgrade log levels to DEBUG (dsbulk) and INFO (driver, Netty, Reactor)
+        seLoggerThreshold("com.datastax.oss.dsbulk", Level.DEBUG);
+        seLoggerThreshold("com.datastax.oss.driver", Level.INFO);
+        seLoggerThreshold("com.datastax.dse.driver", Level.INFO);
+        seLoggerThreshold("io.netty", Level.INFO);
+        seLoggerThreshold("reactor.core", Level.INFO);
+    }
+
+    @VisibleForTesting
+    public static void setVerbosityMax() {
+        setAppenderThreshold(CONSOLE_APPENDER, "TRACE");
+        setAppenderThreshold(MAIN_LOG_FILE_APPENDER, "TRACE");
+        setAppenderEncoderPattern(CONSOLE_APPENDER, DEBUG_LAYOUT_PATTERN);
+        setAppenderEncoderPattern(MAIN_LOG_FILE_APPENDER, DEBUG_LAYOUT_PATTERN);
+        // downgrade log levels to TRACE (dsbulk, driver) and DEBUG (Netty, Reactor)
+        seLoggerThreshold("com.datastax.oss.dsbulk", Level.TRACE);
+        seLoggerThreshold("com.datastax.oss.driver", Level.TRACE);
+        seLoggerThreshold("com.datastax.dse.driver", Level.TRACE);
+        seLoggerThreshold("io.netty", Level.DEBUG);
+        seLoggerThreshold("reactor.core", Level.DEBUG);
+    }
+
+    @VisibleForTesting
+    public static void setVerbosityNormal() {
+        setAppenderThreshold(CONSOLE_APPENDER, "INFO");
+        setAppenderThreshold(MAIN_LOG_FILE_APPENDER, "INFO");
+        // These levels correspond to the ones declared in logback.xml,
+        // but it doesn't hurt to force them programmatically
+        seLoggerThreshold("com.datastax.oss.dsbulk", Level.INFO);
+        seLoggerThreshold("com.datastax.oss.driver", Level.WARN);
+        seLoggerThreshold("com.datastax.dse.driver", Level.WARN);
+        seLoggerThreshold("io.netty", Level.WARN);
+        seLoggerThreshold("reactor.core", Level.WARN);
+    }
+
+    private static void seLoggerThreshold(String s, Level debug) {
+        if (!(LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) instanceof ch.qos.logback.classic.Logger)) {
+            // This is workaround to avoid runtime errors when the backfill CLI is invoked as a pulsar admin extention
+            // where the logger type is of type org.apache.logging.slf4j.Log4jLogger
+            return;
+        }
+        ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(s);
+        logger.setLevel(debug);
+    }
+
+    private static void setAppenderThreshold(String appenderName, String level) {
+        if (!(LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) instanceof ch.qos.logback.classic.Logger)) {
+            // This is workaround to avoid runtime errors when the backfill CLI is invoked as a pulsar admin extention
+            // where the logger type is of type org.apache.logging.slf4j.Log4jLogger
+            return;
+        }
+        ch.qos.logback.classic.Logger root =
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        Appender<ILoggingEvent> appender = root.getAppender(appenderName);
+        List<Filter<ILoggingEvent>> filters = appender.getCopyOfAttachedFiltersList();
+        for (Filter<ILoggingEvent> filter : filters) {
+            if (filter instanceof ThresholdFilter) {
+                ThresholdFilter thresholdFilter = (ThresholdFilter) filter;
+                thresholdFilter.setLevel(level);
+            }
+        }
+    }
+
+    private static void setAppenderEncoderPattern(String appenderName, String pattern) {
+        if (!(LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) instanceof ch.qos.logback.classic.Logger)) {
+            // This is workaround to avoid runtime errors when the backfill CLI is invoked as a pulsar admin extention
+            // where the logger type is of type org.apache.logging.slf4j.Log4jLogger
+            return;
+        }
+        ch.qos.logback.classic.Logger root =
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        OutputStreamAppender<ILoggingEvent> appender =
+                ((OutputStreamAppender<ILoggingEvent>) root.getAppender(appenderName));
+        LoggerContext lc = root.getLoggerContext();
+        PatternLayoutEncoder ple = new PatternLayoutEncoder();
+        ple.setPattern(pattern);
+        ple.setContext(lc);
+        ple.setCharset(StandardCharsets.UTF_8);
+        ple.start();
+        appender.setEncoder(ple);
+    }
+
+    private static boolean isPercent(String maxErrors) {
+        return maxErrors.contains("%");
+    }
+
+    private static void validatePercentageRange(float maxErrorRatio) {
+        if (maxErrorRatio <= 0 || maxErrorRatio >= 1) {
+            throw new IllegalArgumentException(
+                    "maxErrors must either be a number, or percentage between 0 and 100 exclusive.");
+        }
+    }
+
+    private static void validateNumericVerbosity(int verbosity) {
+        if (verbosity < com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings.Verbosity.quiet.ordinal() || verbosity > com.datastax.oss.dsbulk.workflow.commons.settings.LogSettings.Verbosity.max.ordinal()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Invalid numeric value for dsbulk.log.verbosity, expecting one of: 0 (quiet), 1 (normal), 2 (high) or 3 (max), got: %s.",
+                            verbosity));
+        }
+        LOGGER.warn(
+                "Numeric verbosity levels are deprecated, use 'quiet' (0), 'normal' (1), 'high' (2) or 'max' (3) instead.");
+    }
+}
+

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/exporter/TableExporter.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/exporter/TableExporter.java
@@ -42,12 +42,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TableExporter {
     private static final URL DSBULK_CONFIGURATION_FILE =
-            Objects.requireNonNull(ClassLoader.getSystemResource("logback-dsbulk-embedded.xml"));
+            TableExporter.class.getClassLoader().getResource("logback-dsbulk-embedded.xml");
     private static final Logger LOGGER = LoggerFactory.getLogger(TableExporter.class);
 
     protected final BackfillSettings settings;

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/util/ConnectorUtils.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/util/ConnectorUtils.java
@@ -16,6 +16,7 @@
 
 package com.datastax.oss.cdc.backfill.util;
 
+import com.datastax.oss.cdc.backfill.dsbulk.BackfillConfigUtil;
 import com.datastax.oss.dsbulk.config.ConfigUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -26,7 +27,9 @@ import java.util.Iterator;
 
 public class ConnectorUtils {
     public static Config createConfig(String path, Object... additionalArgs) {
-        Config baseConfig = ConfigUtils.createApplicationConfig(null).resolve().getConfig(path);
+        Config baseConfig = BackfillConfigUtil.
+                createApplicationConfig(null, ConnectorUtils.class.getClassLoader())
+                .resolve().getConfig(path);
         if (additionalArgs != null && additionalArgs.length != 0) {
             Iterator<Object> it = Arrays.asList(additionalArgs).iterator();
             while (it.hasNext()) {
@@ -35,7 +38,9 @@ public class ConnectorUtils {
                 baseConfig =
                         ConfigFactory.parseString(
                                         key + "=" + value,
-                                        ConfigParseOptions.defaults().setOriginDescription("command line argument"))
+                                        ConfigParseOptions.defaults()
+                                                .setOriginDescription("command line argument")
+                                                .setClassLoader(ConnectorUtils.class.getClassLoader()))
                                 .withFallback(baseConfig);
             }
         }

--- a/backfill-cli/src/main/resources/META-INF/MANIFEST.MF
+++ b/backfill-cli/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Nar-Version: 2.2.3
+Nar-Id: pulsar-cassandra-cdc-admin-nar
+Nar-Group: com.datastax.oss
+Main-Class: com.datastax.oss.cdc.backfill.BackfillCLI
+

--- a/backfill-cli/src/main/resources/META-INF/services/command_factory.yml
+++ b/backfill-cli/src/main/resources/META-INF/services/command_factory.yml
@@ -1,0 +1,3 @@
+factoryClass: 'com.datastax.oss.cdc.backfill.admin.CommandFactory'
+name: 'cassandra-cdc'
+description: 'Cassandra CDC - Pulsar Admin Custom Commands'

--- a/backfill-cli/src/main/resources/driver-reference.conf
+++ b/backfill-cli/src/main/resources/driver-reference.conf
@@ -1,0 +1,3205 @@
+# This file is include in the classpath to work around the following error:
+# Merge of DSBulk forced driver settings,command line argument: 7,command line argument: 5,driver-reference.conf @ jar:file:/pulsar-cassandra-admin-2.2.3-nar.nar-unpacked/META-INF/bundled-dependencies/backfill-cli-2.2.3-all.jar!/driver-reference.conf: 152: No configuration setting found for key 'advanced.session-leak'.
+# com.typesafe.config.ConfigException$Missing: merge of DSBulk forced driver settings,command line argument: 7,command line argument: 5,driver-reference.conf @ jar:file:/pulsar-cassandra-admin-2.2.3-nar.nar-unpacked/META-INF/bundled-dependencies/backfill-cli-2.2.3-all.jar!/driver-reference.conf: 152: No configuration setting found for key 'advanced.session-leak'
+# This is because the com.datastax.oss.dsbulk.workflow.commons.settings.DriverSettings class is not class loader aware
+
+# Reference configuration for the DataStax Bulk Loader.
+#
+# All the values declared here will be used as defaults if you don't override them through
+# command line arguments.
+#
+# This file is in HOCON format, see https://github.com/typesafehub/config/blob/master/HOCON.md.
+#
+# Note that a paragraph is written in one line, and paragraphs are separated by a blank line.
+# This has the benefit of rendering well in markdown as well as plain-text help output (since
+# the help text formatter wraps lines appropriately).
+#
+# Also note that the order of declaration of settings in this file will be preserved in generated
+# documentation (help on the command line and generated setting.md file).
+# See com.datastax.oss.dsbulk.cli.help.HelpEmitterHelpEmitter and
+# SettingsDocumentor.
+#
+# Usage of references in this file should be avoided, as they may cause documentation generation to
+# fail.
+
+# DSBulk configuration.
+dsbulk {
+
+  # Driver-specific configuration.
+  #
+  # **DEPRECATED**. This entire section is deprecated since DSBulk 1.4.0. Please configure the Java driver directly using the `datastax-java-driver` configuration namespace. Refer to the [DataStax Java Driver documentation](https://docs.datastax.com/en/developer/java-driver/latest/) for more information.
+  driver {
+
+    # The contact points to use for the initial connection to the cluster. This must be a comma-separated list of hosts, each specified by a host-name or ip address. If the host is a DNS name that resolves to multiple A-records, all the corresponding addresses will be used. Do not use `localhost` as a host-name (since it resolves to both IPv4 and IPv6 addresses on some platforms). The port for all hosts must be specified with `driver.port`.
+    #
+    # This setting has no effect when connecting to an Astra database with a secure connect bundle.
+    #
+    # **DEPRECATED**. Use `datastax-java-driver.basic.contact-points` instead.
+    # **DEPRECATED**. Use `datastax-java-driver.basic.contact-points` instead.
+    hosts = ["127.0.0.1"]
+
+    # The native transport port to connect to. This must match Cassandra's [native_transport_port](https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html#configCassandra_yaml_r__native_transport_port) configuration option.
+    #
+    # Note that all nodes in a cluster must accept connections on the same port number. Mixed-port clusters are not supported.
+    #
+    # This setting has no effect when connecting to an Astra database with a secure connect bundle.
+    #
+    # **DEPRECATED**. Use `datastax-java-driver.basic.contact-points` instead.
+    port = 9042
+
+    # Native Protocol-specific settings.
+    protocol {
+
+      # Specify the compression algorithm to use. Valid values are: `NONE`, `LZ4`, `SNAPPY`.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.protocol.compression` instead.
+      compression = NONE
+
+    }
+
+    # Pooling-specific settings.
+    #
+    # The driver maintains a connection pool to each node, according to the distance assigned to it by the load balancing policy. If the distance is `IGNORED`, no connections are maintained.
+    pooling {
+
+      # Pooling settings for nodes at LOCAL distance.
+      local {
+
+        # The number of connections in the pool for nodes at "local" distance.
+        #
+        # **DEPRECATED**. Use `datastax-java-driver.advanced.connection.pool.local.size` instead.
+        connections = 8
+
+        # The maximum number of requests (1 to 32768) that can be executed concurrently on a connection. If connecting to legacy clusters using protocol version 1 or 2, any value greater than 128 will be capped at 128 and a warning will be logged.
+        #
+        # **DEPRECATED**. Use `datastax-java-driver.advanced.connection.max-requests-per-connection` instead.
+        requests = 32768
+
+      }
+
+      # Pooling settings for nodes at REMOTE distance.
+      remote {
+
+        # The number of connections in the pool for remote nodes.
+        #
+        # **DEPRECATED**. Use `datastax-java-driver.advanced.connection.pool.remote.size` instead.
+        connections = 1
+
+        # The maximum number of requests (1 to 32768) that can be executed concurrently on a connection. If connecting to legacy clusters using protocol version 1 or 2, any value greater than 128 will be capped at 128 and a warning will be logged.
+        #
+        # **DEPRECATED**. Use `datastax-java-driver.advanced.connection.max-requests-per-connection` instead.
+        requests = 1024
+
+      }
+
+      # The heartbeat interval. If a connection stays idle for that duration (no reads), the driver sends a dummy message on it to make sure it's still alive. If not, the connection is trashed and replaced.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.heartbeat.interval` instead.
+      heartbeat = 30 seconds
+
+    }
+
+    # Query-related settings.
+    query {
+
+      # The consistency level to use for all queries. Note that stronger consistency levels usually result in reduced throughput. In addition, any level higher than `ONE` will automatically disable continuous paging, which can dramatically reduce read throughput.
+      #
+      # Valid values are: `ANY`, `LOCAL_ONE`, `ONE`, `TWO`, `THREE`, `LOCAL_QUORUM`, `QUORUM`, `EACH_QUORUM`, `ALL`.
+      #
+      # Note: on Cloud deployments, the only accepted consistency level when writing is `LOCAL_QUORUM`. Therefore, the default value is `LOCAL_ONE`, except when loading in Cloud deployments, in which case the default is automatically changed to `LOCAL_QUORUM`.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.basic.request.consistency` instead.
+      consistency = LOCAL_ONE
+
+      # The serial consistency level to use for writes. Only applicable if the data is inserted using lightweight transactions, ignored otherwise. Valid values are: `SERIAL` and `LOCAL_SERIAL`.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.basic.request.serial-consistency` instead.
+      serialConsistency = LOCAL_SERIAL
+
+      # The page size, or how many rows will be retrieved simultaneously in a single network round trip. The ideal page size depends on the size of the rows being unloaded: larger page sizes may have a positive impact on throughput for small rows, and vice versa.
+      # This setting will limit the number of results loaded into memory simultaneously during unloading or counting. Setting this value to any negative value or zero will disable paging, i.e., the entire result set will be retrieved in one pass (not recommended). Not applicable for loading. Note that this setting controls paging for regular queries; to customize the page size for continuous queries, use the `executor.continuousPaging.pageSize` setting instead.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.basic.request.page-size` instead.
+      fetchSize = 5000
+
+      # The default idempotence of statements generated by the loader.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.basic.request.default-idempotence` instead.
+      idempotence = true
+
+    }
+
+    # Socket-related settings.
+    socket {
+      # The time the driver waits for a request to complete. This is a global limit on the duration of a `session.execute()` call, including any internal retries the driver might do.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.basic.request.timeout` instead.
+      readTimeout = 60 seconds
+
+    }
+
+    # Authentication settings.
+    #
+    # **DEPRECATED**. see [the driver documentation page on authentication](https://docs.datastax.com/en/developer/java-driver/latest/manual/core/authentication/) for more information.
+    auth {
+
+      # The name of the AuthProvider to use. Valid choices are:
+      #
+      #  - None: no authentication.
+      #  - PlainTextAuthProvider: Uses `com.datastax.oss.driver.internal.core.auth.PlainTextAuthProvider` for authentication. Supports SASL authentication using the `PLAIN` mechanism (plain text authentication), and also supports optional proxy authentication (for DSE clusters only).
+      #  - DseGSSAPIAuthProvider: Uses `com.datastax.dse.driver.internal.core.auth.DseGssApiAuthProvider` for authentication. Supports SASL authentication to DSE clusters using the `GSSAPI` mechanism (Kerberos authentication), and also supports optional proxy authentication.
+      #    - Note: When using this provider you may have to set the `java.security.krb5.conf` system property to point to your `krb5.conf` file (e.g. set the `DSBULK_JAVA_OPTS` environment variable to `-Djava.security.krb5.conf=/home/user/krb5.conf`). See the [Oracle Java Kerberos documentation](https://docs.oracle.com/javase/7/docs/technotes/guides/security/jgss/tutorials/KerberosReq.html) for more details.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.auth-provider.class` instead.
+      provider = None
+
+      # The username to use. Providers that accept this setting:
+      #
+      #  - `PlainTextAuthProvider`
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.auth-provider.username` instead.
+      # @type string
+      username = null
+
+      # The password to use. Providers that accept this setting:
+      #
+      #  - `PlainTextAuthProvider`
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.auth-provider.password` instead.
+      # @type string
+      password = null
+
+      # An authorization ID allows the currently authenticated user to act as a different user (proxy authentication). Providers that accept this setting:
+      #
+      #  - `PlainTextAuthProvider`
+      #  - `DseGSSAPIAuthProvider`
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.auth-provider.authorization-id` instead.
+      # @type string
+      authorizationId = null
+
+      # The Kerberos principal to use. For example, `user@datastax.com`. If left unspecified, the principal is chosen from the first key in the ticket cache or keytab. Providers that accept this setting:
+      #
+      #  - `DseGSSAPIAuthProvider`
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.auth-provider.login-configuration.principal` instead.
+      # @type string
+      principal = null
+
+      # The path of the Kerberos keytab file to use for authentication. If left unspecified, authentication uses a ticket cache. Providers that accept this setting:
+      #
+      #  - `DseGSSAPIAuthProvider`
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.auth-provider.login-configuration.keyTab` instead.
+      # @type string
+      keyTab = null
+
+      # The SASL service name to use. This value should match the username of the Kerberos service principal used by the DSE server. This information is specified in the `dse.yaml` file by the *service_principal* option under the *kerberos_options* section, and may vary from one DSE installation to another - especially if you installed DSE with an automated package installer. Providers that accept this setting:
+      #
+      #  - `DseGSSAPIAuthProvider`
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.auth-provider.service` instead.
+      saslService = "dse"
+
+    }
+
+    # Encryption-specific settings.
+    #
+    # For more information about how to configure this section, see the Java Secure Socket Extension (JSSE) Reference Guide: http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html. You can also check the DataStax Java driver documentation on SSL: http://docs.datastax.com/en/developer/java-driver-dse/latest/manual/ssl/
+    #
+    # This setting has no effect when connecting to an Astra database with a secure connect bundle.
+    #
+    # **DEPRECATED**. see [the driver documentation page on SSL](https://docs.datastax.com/en/developer/java-driver/latest/manual/core/ssl/) for more information.
+    ssl {
+
+      # The SSL provider to use. Valid values are:
+      #
+      # - **None**: no SSL.
+      # - **JDK**: uses the JDK SSLContext
+      # - **OpenSSL**: uses Netty's native support for OpenSSL. It provides better performance and generates less garbage. This is the recommended provider when using SSL.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.ssl-engine-factory.class` instead. Also, note that SSL contexts created with any of these deprecated providers will always have hostname verification enabled. If you want to disable hostname verification, configure your SSL context directly through the driver and set the `datastax-java-driver.advanced.ssl-engine-factory.hostname-validation` option accordingly.
+      provider = None
+
+      # The cipher suites to enable. For example:
+      #
+      # `cipherSuites = ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"]`
+      #
+      # This property is optional. If it is not present, the driver won't explicitly enable cipher suites, which according to the JDK documentation results in "a minimum quality of service".
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.ssl-engine-factory.cipher-suites` instead.
+      cipherSuites = []
+
+      # The truststore to use to validate remote peer certificates. This section is valid for both JDK and OpenSSL providers.
+      truststore {
+
+        # The path of the truststore file. This setting is optional. If left unspecified, server certificates will not be validated.
+        #
+        # **DEPRECATED**. Use `datastax-java-driver.advanced.ssl-engine-factory.truststore-path` instead.
+        # @type string
+        path = null
+
+        # The truststore password.
+        #
+        # **DEPRECATED**. Use `datastax-java-driver.advanced.ssl-engine-factory.truststore-password` instead.
+        # @type string
+        password = null
+
+        # The algorithm to use for the SSL truststore. Valid values are: `PKIX`, `SunX509`.
+        #
+        # **DEPRECATED**. Use `datastax-java-driver.advanced.ssl-engine-factory.truststore-password` instead.
+        algorithm = SunX509
+
+      }
+
+      # The keystore to use for client authentication.
+      #
+      # This section is only valid when using JDK provider; it is ignored otherwise.
+      keystore {
+
+        # The path of the keystore file. This setting is optional. If left unspecified, no client authentication will be used.
+        # @type string
+        path = null
+
+        # The keystore password.
+        # @type string
+        password = null
+
+        # The algorithm to use for the SSL keystore. Valid values are: `SunX509`, `NewSunX509`.
+        #
+        # **DEPRECATED**. Provide a custom implementation in `datastax-java-driver.advanced.ssl-engine-factory.class` if you need to change this; otherwise the driver now uses `TrustManagerFactory.getDefaultAlgorithm()` by default.
+        algorithm = SunX509
+
+      }
+
+      # OpenSSL configuration for client authentication. This section is only valid when using OpenSSL provider; it is ignored otherwise.
+      openssl {
+
+        # The path of the certificate chain file. This setting is optional. If left unspecified, no client authentication will be used.
+        #
+        # **DEPRECATED**. Using OpenSSL is now considered a driver advanced feature; see [this documentation page](https://docs.datastax.com/en/developer/java-driver/latest/manual/core/ssl/#netty) for more information.
+        # @type string
+        keyCertChain = null
+
+        # The path of the private key file.
+        #
+        # **DEPRECATED**. Using OpenSSL is now considered a driver advanced feature; see [this documentation page](https://docs.datastax.com/en/developer/java-driver/latest/manual/core/ssl/#netty) for more information.
+        # @type string
+        privateKey = null
+
+      }
+
+    }
+
+    # The name of the timestamp generator to use. Only the following built-in options are supported:
+    #
+    # - AtomicMonotonicTimestampGenerator: timestamps are guaranteed to be unique across all client threads.
+    # - ThreadLocalTimestampGenerator: timestamps are guaranteed to be unique within each thread only.
+    # - ServerSideTimestampGenerator: do not generate timestamps, let the server assign them.
+    #
+    # **DEPRECATED**. Use `datastax-java-driver.advanced.timestamp-generator.class`.
+    timestampGenerator = AtomicMonotonicTimestampGenerator
+
+    # The name of the address translator to use. This is only needed if the nodes are not directly reachable from the machine on which dsbulk is running (for example, the dsbulk machine is in a different network region and needs to use a public IP, or it connects through a proxy).
+    #
+    # This setting has no effect when connecting to an Astra database with a secure connect bundle.
+    #
+    # **DEPRECATED**. Use `datastax-java-driver.advanced.address-translator.class`. The only currently supported value is the default one, `IdentityTranslator`.
+    addressTranslator = IdentityTranslator
+
+    # Settings for various driver policies.
+    policy {
+
+      # Maximum number of retries for a timed-out request.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.retry-policy.max-retries`.
+      maxRetries = 10
+
+      # Load balancing policy settings.
+      #
+      # **DEPRECATED**. This section is now deprecated and obsolete; most of its settings have no effect anymore. DSBulk now uses `com.datastax.oss.driver.internal.core.loadbalancing.DcInferringLoadBalancingPolicy` by default. Refer to the [driver documentation page on load balancing](https://docs.datastax.com/en/developer/java-driver/latest/manual/core/load_balancing/) for more details.
+      lbp {
+
+        # The name of the load balancing policy.
+        #
+        # **OBSOLETE**. This setting is not honored anymore. To specify a load balancing policy, use `datastax-java-driver.basic.load-balancing-policy.class`.
+        # @type string
+        name = null
+
+        # Settings for the DseLoadBalancingPolicy. See the driver documentation for this policy for more details.
+        # **OBSOLETE**. This section is not honored anymore.
+        dse {
+
+          # The child policy that the specified `dse` policy wraps.
+          #
+          # **OBSOLETE**. This setting is not honored anymore.
+          childPolicy = "roundRobin"
+
+        }
+
+        # Settings for the DCAwareRoundRobinPolicy. See the driver documentation for this policy for more details.
+        # **OBSOLETE**. This section is not honored anymore, except for `dcAwareRoundRobin.localDc`.
+        dcAwareRoundRobin {
+
+          # The datacenter name (commonly dc1, dc2, etc.) local to the machine on which dsbulk is running, so that requests are sent to nodes in the local datacenter whenever possible.
+          #
+          # This setting has no effect when connecting to an Astra database with a secure connect bundle.
+          #
+          # **DEPRECATED**. Use `datastax-java-driver.basic.load-balancing-policy.local-datacenter` instead.
+          # @type string
+          localDc = null
+
+          # Enable or disable whether to allow remote datacenters to count for local consistency level in round robin awareness.
+          #
+          # **OBSOLETE**. This setting is not honored anymore.
+          allowRemoteDCsForLocalConsistencyLevel = false
+
+          # The number of hosts per remote datacenter that the round robin policy should consider.
+          #
+          # **OBSOLETE**. This setting is not honored anymore.
+          usedHostsPerRemoteDc = 0
+
+        }
+
+        # Settings for the TokenAwarePolicy. See the driver documentation for this policy for more details.
+        # **OBSOLETE**. This section is not honored anymore.
+        tokenAware {
+
+          # The child policy that the specified `tokenAware` policy wraps.
+          #
+          # **OBSOLETE**. This setting is not honored anymore.
+          childPolicy = "roundRobin"
+
+          # Specify how to order replicas.
+          #
+          # Valid values are all `TokenAwarePolicy.ReplicaOrdering` enum constants:
+          #
+          # - RANDOM: Return replicas in a different, random order for each query plan. This is the default strategy;
+          # for loading, it should be preferred has it can improve performance by distributing writes across replicas.
+          # - TOPOLOGICAL: Order replicas by token ring topology, i.e. always return the "primary" replica first.
+          # - NEUTRAL: Return the replicas in the exact same order in which they appear in the child policy's query plan.
+          #
+          # **OBSOLETE**. This setting is not honored anymore.
+          replicaOrdering = RANDOM
+
+        }
+
+        # Settings for the WhiteListPolicy. See the driver documentation for this policy for more details.
+        # **OBSOLETE**. This section is not honored anymore, except for `whiteList.hosts`.
+        whiteList {
+
+          # The child policy that the specified `whiteList` policy wraps.
+          #
+          # **OBSOLETE**. This setting is not honored anymore.
+          childPolicy = "roundRobin"
+
+          # List of hosts to white list. This must be a comma-separated list of hosts, each specified by a host-name or ip address. If the host is a DNS name that resolves to multiple A-records, all the corresponding addresses will be used. Do not use `localhost` as a host-name (since it resolves to both IPv4 and IPv6 addresses on some platforms).
+          #
+          # **DEPRECATED**. Use `datastax-java-driver.basic.load-balancing-policy.filter.class` instead.
+          hosts = []
+
+        }
+
+      }
+
+    }
+
+  }
+
+  # Log and error management settings.
+  log {
+
+    # The desired level of verbosity. Valid values are:
+    #
+    # - `quiet`: DSBulk will only log WARN and ERROR messages.
+    # - `normal`: DSBulk will log a few INFO messages, as well as WARN and ERROR messages.
+    # - `high`: DSBulk will also print some DEBUG messages at the beginning of the operation, such as DSBulk's settings, inferred query, and the read and write concurrency.
+    # - `max`: DSBulk will print numerous DEBUG messages from itself, the driver, and from some important libraries (Netty and Reactor).
+    #
+    # Verbosity levels `quiet`, `normal` and `high` are suitable to use in a production environment. Verbosity `high` is the recommended level to diagnose problems related to configuration and/or performance in production environments. Verbosity `max`, however, should only be used for debugging, and preferably on small amounts of data; otherwise it could print hundreds of gigabytes of text to the main log file and to the console.
+    verbosity = normal
+
+    # Whether to print record sources in debug files. When set to true (the default), debug files will contain, for each record that failed to be processed, its original source, such as the text line that the record was parsed from.
+    #
+    # Furthermore, when loading, enabling this option also enables the creation of so-called "bad files", that is, files containing the original lines that could not be inserted; these files could then be used as the data source of a subsequent load operation that would load only the failed records.
+    #
+    # This feature is useful to locate failed records more easily and diagnose processing failures – especially if the original data source is a remote one, such as an FTP or HTTP URL.
+    #
+    # But for this feature to be possible, record sources must be kept in memory until the record is fully processed. For large record sizes (over 1 megabyte per record), retaining record sources in memory could put a high pressure on the JVM heap, thus exposing the operation to out-of-memory errors. This phenomenon is exacerbated when batching is enabled. If you are experiencing such errors, consider disabling this option.
+    #
+    # Note that, regardless of the value of this option, DSBulk will always print the record's *resource* – that is, the file name or the database table where it came from – and the record's *position* – that is, the ordinal position of the record inside the resource, when available (for example, this could be the line number in a CSV file).
+    sources = true
+
+    # The writable directory where all log files will be stored; if the directory specified does not exist, it will be created. URLs are not acceptable (not even `file:/` URLs). Log files for a specific run, or execution, will be located in a sub-directory under the specified directory. Each execution generates a sub-directory identified by an "execution ID". See `engine.executionId` for more information about execution IDs. Relative paths will be resolved against the current working directory. Also, for convenience, if the path begins with a tilde (`~`), that symbol will be expanded to the current user's home directory.
+    directory = "./logs"
+
+    # The maximum number of errors to tolerate before aborting the entire operation. This can be expressed either as an absolute number of errors - in which case, set this to an integer greater than or equal to zero; or as a percentage of total rows processed so far - in which case, set this to a string of the form `N%`, where `N` is a decimal number between 0 and 100 exclusive (e.g. "20%"). Setting this value to any negative integer disables this feature (not recommended).
+    maxErrors = 100
+
+    # The maximum number of query warnings to log before muting them. Query warnings are sent by the server (for example, if the number of statements in a batch is greater than the warning threshold configured on the server). They are useful to diagnose suboptimal configurations but tend to be too invasive, which is why DSBulk by default will only log the 50 first query warnings; any subsequent warnings will be muted and won't be logged at all. Setting this value to any negative integer disables this feature (not recommended).
+    maxQueryWarnings = 50
+
+    # Whether or not to use ANSI colors and other escape sequences in log messages printed to the console. Valid values are:
+    #
+    # - `normal`: this is the default option. DSBulk will only use ANSI when the terminal is:
+    #   - compatible with ANSI escape sequences; all common terminals on *nix and BSD systems, including MacOS, are ANSI-compatible, and some popular terminals for Windows (Mintty, MinGW);
+    #   - a standard Windows DOS command prompt (ANSI sequences are translated on the fly).
+    # - `force`: DSBulk will use ANSI, even if the terminal has not been detected as ANSI-compatible.
+    # - `disabled`: DSBulk will not use ANSI.
+    ansiMode = normal
+
+    # Settings controlling how statements are printed to log files.
+    stmt {
+
+      # The desired log level. Valid values are:
+      #
+      # - ABRIDGED: Print only basic information in summarized form.
+      # - NORMAL: Print basic information in summarized form, and the statement's query string, if available. For batch statements, this verbosity level also prints information about the batch's inner statements.
+      # - EXTENDED: Print full information, including the statement's query string, if available, and the statement's bound values, if available. For batch statements, this verbosity level also prints all information available about the batch's inner statements.
+      level = EXTENDED
+
+      # The maximum length for a query string. Query strings longer than this value will be truncated.
+      #
+      # Setting this value to `-1` disables this feature (not recommended).
+      maxQueryStringLength = 500
+
+      # The maximum number of bound values to print. If the statement has more bound values than this limit, the exceeding values will not be printed.
+      #
+      # Setting this value to `-1` makes the maximum number of bound values unlimited (not recommended).
+      maxBoundValues = 50
+
+      # The maximum length for a bound value. Bound values longer than this value will be truncated.
+      #
+      # Setting this value to `-1` makes the maximum length for a bound value unlimited (not recommended).
+      maxBoundValueLength = 50
+
+      # The maximum number of inner statements to print for a batch statement. Only applicable for batch statements, ignored otherwise. If the batch statement has more children than this value, the exceeding child statements will not be printed.
+      #
+      # Setting this value to `-1` disables this feature (not recommended).
+      maxInnerStatements = 10
+
+    }
+
+    # Settings controlling how rows are printed to log files.
+    row {
+
+      # The maximum number of result set values to print. If the row has more result set values than this limit, the exceeding values will not be printed.
+      #
+      # Setting this value to `-1` makes the maximum number of result set values unlimited (not recommended).
+      maxResultSetValues = 50
+
+      # The maximum length for a result set value. Result set values longer than this value will be truncated.
+      #
+      # Setting this value to `-1` makes the maximum length for a result set value unlimited (not recommended).
+      maxResultSetValueLength = 50
+
+    }
+
+    # Settings controlling DSBulk's checkpointing behavior, that is, its ability to resume an interrupted operation from where it left off.
+    checkpoint {
+
+      # Whether to enable checkpointing for the current operation. When set to true (the default), DSBulk will track records that were processed and will produce a checkpoint file at the end of the operation. The checkpoint file can then be used later on to resume the same operation, if not all records were processed, or if the operation was interrupted.
+      #
+      # Note that a checkpointed operation consumes more memory, and is slightly slower. If you don't need checkpointing, you should disable it.
+      enabled = true
+
+      # The path to a checkpoint file to resume an operation from. If this option is set, and depending on the replay strategy, then only unprocessed and/or failed data will be re-processed.
+      #
+      # When using a checkpoint file to resume an operation, make sure that both operations target the same dataset:
+      #
+      # - When loading, make sure that the files to load weren't renamed or moved, otherwise all files would be considered new and loaded entirely. Also, if the file contents have changed, new records may go unnoticed, or cause other records to be processed twice.
+      # - When unloading, make sure that the read query, the token distribution across the ring, the number of splits (see `schema.splits`) and the data to read are all the same across operations, otherwise the unloaded data could be inconsistent.
+      # @type string
+      file = null
+
+      # The replay strategy to use when resuming an operation from a checkpoint file. Valid values are:
+      # - `resume`: DSBulk will only process new records from resources that weren't consumed entirely. Records that were already processed will be ignored, including rejected ones (rejected records are always written to bad files). This is the safest option when loading if the operation is not idempotent.
+      # - `retry`: this is the default option. DSBulk will process new and rejected records from resources that weren't consumed entirely. Note that this strategy may result in some rows being inserted twice and thus should only be used if the operation is idempotent.
+      # - `retryAll`: like `retry`, DSBulk will process new and rejected records, but unlike `retry`, it will process all resources, including those marked as consumed entirely. Note that this strategy may result in some rows being inserted twice and thus should only be used if the operation is idempotent.
+      replayStrategy = retry
+    }
+  }
+
+  # Conversion-specific settings. These settings apply for both load and unload workflows.
+  #
+  # When writing, these settings determine how record fields emitted by connectors are parsed.
+  #
+  # When unloading, these settings determine how row cells emitted by DSE are formatted.
+  #
+  # When counting, these settings are ignored.
+  codec {
+
+    # The locale to use for locale-sensitive conversions.
+    locale = en_US
+
+    # The time zone to use for temporal conversions. When loading, the time zone will be used to obtain a timestamp from inputs that do not convey any explicit time zone information. When unloading, the time zone will be used to format all timestamps.
+    timeZone = UTC
+
+    # Comma-separated list of case-sensitive strings that should be mapped to `null`. For loading, when a record field value exactly matches one of the specified strings, the value is replaced with `null` before writing to the database. For unloading, this setting is only applicable for string-based connectors, such as the CSV connector: the first string specified will be used to change a row cell containing `null` to the specified string when written out.
+    #
+    # For example, setting this to `["NULL"]` will cause a field containing the word `NULL` to be mapped to `null` while loading, and a column containing `null` to be converted to the word `NULL` while unloading.
+    #
+    # The default value is `[]` (no strings are mapped to `null`). In the default mode, DSBulk behaves as follows:
+    # * When loading, if the target CQL type is textual (i.e. text, varchar or ascii), the original field value is left untouched; for other types, if the value is an empty string, it is converted to `null`.
+    # * When unloading, `null` values are left untouched.
+    #
+    # Note that, regardless of this setting, DSBulk will always convert empty strings to `null` if the target CQL type is not textual when loading (i.e. not text, varchar or ascii).
+    #
+    # This setting is applied before `schema.nullToUnset`, hence any `null` produced by a null-string can still be left unset if required.
+    nullStrings: []
+
+    # Specify how true and false representations can be used by dsbulk. Each representation is of the form `true_value:false_value`, case-insensitive. For loading, all representations are honored: when a record field value exactly matches one of the specified strings, the value is replaced with `true` of `false` before writing to the database. For unloading, this setting is only applicable for string-based connectors, such as the CSV connector: the first representation will be used to format booleans before they are written out, and all others are ignored.
+    booleanStrings = ["1:0", "Y:N", "T:F", "YES:NO", "TRUE:FALSE"]
+
+    # Set how true and false representations of numbers are interpreted. The representation is of the form `true_value,false_value`. The mapping is reciprocal, so that numbers are mapping to Boolean and vice versa. All numbers unspecified in this setting are rejected.
+    booleanNumbers = [1, 0]
+
+    # The `DecimalFormat` pattern to use for conversions between `String` and CQL numeric types.
+    #
+    # See [java.text.DecimalFormat](https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html) for details about the pattern syntax to use.
+    #
+    # Most inputs are recognized: optional localized thousands separator, localized decimal separator, or optional exponent. Using locale `en_US`, `1234`, `1,234`, `1234.5678`, `1,234.5678` and `1,234.5678E2` are all valid. For unloading and formatting, rounding may occur and cause precision loss. See `codec.formatNumbers` and `codec.roundingStrategy`.
+    number = "#,###.##"
+
+    # Whether or not to use the `codec.number` pattern to format numeric output. When set to `true`, the numeric pattern defined by `codec.number` will be applied. This allows for nicely-formatted output, but may result in rounding (see `codec.roundingStrategy`), or alteration of the original decimal's scale. When set to `false`, numbers will be stringified using the `toString()` method, and will never result in rounding or scale alteration. Only applicable when unloading, and only if the connector in use requires stringification, because the connector, such as the CSV connector, does not handle raw numeric data; ignored otherwise.
+    formatNumbers = false
+
+    # The rounding strategy to use for conversions from CQL numeric types to `String`.
+    #
+    # Valid choices: any `java.math.RoundingMode` enum constant name, including: `CEILING`, `FLOOR`, `UP`, `DOWN`, `HALF_UP`, `HALF_EVEN`, `HALF_DOWN`, and `UNNECESSARY`. The precision used when rounding is inferred from the numeric pattern declared under `codec.number`. For example, the default `codec.number` (`#,###.##`) has a rounding precision of 2, and the number 123.456 would be rounded to 123.46 if `roundingStrategy` was set to `UP`. The default value will result in infinite precision, and ignore the `codec.number` setting.
+    #
+    # Only applicable when unloading, if `codec.formatNumbers` is true and if the connector in use requires stringification, because the connector, such as the CSV connector, does not handle raw numeric data; ignored otherwise.
+    roundingStrategy = UNNECESSARY
+
+    # This setting can mean one of three possibilities:
+    #
+    # - The value is outside the range of the target CQL type. For example, trying to convert 128 to a CQL `tinyint` (max value of 127) results in overflow.
+    # - The value is decimal, but the target CQL type is integral. For example, trying to convert 123.45 to a CQL `int` results in overflow.
+    # - The value's precision is too large for the target CQL type. For example, trying to insert 0.1234567890123456789 into a CQL `double` results in overflow, because there are too many significant digits to fit in a 64-bit double.
+    #
+    # Valid choices:
+    #
+    # - `REJECT`: overflows are considered errors and the data is rejected. This is the default value.
+    # - `TRUNCATE`: the data is truncated to fit in the target CQL type. The truncation algorithm is similar to the narrowing primitive conversion defined in The Java Language Specification, Section 5.1.3, with the following exceptions:
+    #     - If the value is too big or too small, it is rounded up or down to the maximum or minimum value allowed, rather than truncated at bit level. For example, 128 would be rounded down to 127 to fit in a byte, whereas Java would have truncated the exceeding bits and converted to -127 instead.
+    #     - If the value is decimal, but the target CQL type is integral, it is first rounded to an integral using the defined rounding strategy, then narrowed to fit into the target type. This can result in precision loss and should be used with caution.
+    #
+    # Only applicable for loading, when parsing numeric inputs; it does not apply for unloading, since formatting never results in overflow.
+    overflowStrategy = REJECT
+
+    # The temporal pattern to use for `String` to CQL `timestamp` conversion. Valid choices:
+    #
+    # - A date-time pattern such as `yyyy-MM-dd HH:mm:ss`.
+    # - A pre-defined formatter such as `ISO_ZONED_DATE_TIME` or `ISO_INSTANT`. Any public static field in `java.time.format.DateTimeFormatter` can be used.
+    # - The special formatter `CQL_TIMESTAMP`, which is a special parser that accepts all valid CQL literal formats for the `timestamp` type.
+    # - The special formatter `UNITS_SINCE_EPOCH`, which is a special parser that reads and writes timestamps as numbers representing time units since a given epoch; the unit and the epoch to use can be specified with `codec.unit` and `codec.timestamp`.
+    #
+    # For more information on patterns and pre-defined formatters, see [Patterns for Formatting and Parsing](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns) in Oracle Java documentation.
+    #
+    # For more information about CQL date, time and timestamp literals, see [Date, time, and timestamp format](https://docs.datastax.com/en/dse/6.0/cql/cql/cql_reference/refDateTimeFormats.html?hl=timestamp).
+    #
+    # The default value is the special `CQL_TIMESTAMP` value. When parsing, this format recognizes all CQL temporal literals; if the input is a local date or date/time, the timestamp is resolved using the time zone specified under `timeZone`. When formatting, this format uses the `ISO_OFFSET_DATE_TIME` pattern, which is compliant with both CQL and ISO-8601.
+    timestamp = "CQL_TIMESTAMP"
+
+    # The temporal pattern to use for `String` to CQL `date` conversion. Valid choices:
+    #
+    # - A date-time pattern such as `yyyy-MM-dd`.
+    # - A pre-defined formatter such as `ISO_LOCAL_DATE`. Any public static field in `java.time.format.DateTimeFormatter` can be used.
+    # - The special formatter `UNITS_SINCE_EPOCH`, which is a special parser that reads and writes local dates as numbers representing time units since a given epoch; the unit and the epoch to use can be specified with `codec.unit` and `codec.timestamp`.
+    #
+    # For more information on patterns and pre-defined formatters, see [Patterns for Formatting and Parsing](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns) in Oracle Java documentation.
+    #
+    # For more information about CQL date, time and timestamp literals, see [Date, time, and timestamp format](https://docs.datastax.com/en/dse/6.0/cql/cql/cql_reference/refDateTimeFormats.html?hl=timestamp).
+    date = "ISO_LOCAL_DATE"
+
+    # The temporal pattern to use for `String` to CQL `time` conversion. Valid choices:
+    #
+    # - A date-time pattern, such as `HH:mm:ss`.
+    # - A pre-defined formatter, such as `ISO_LOCAL_TIME`. Any public static field in `java.time.format.DateTimeFormatter` can be used.
+    # - The special formatter `UNITS_SINCE_EPOCH`, which is a special parser that reads and writes local times as numbers representing time units since a given epoch; the unit and the epoch to use can be specified with `codec.unit` and `codec.timestamp`.
+    #
+    # For more information on patterns and pre-defined formatters, see [Patterns for formatting and Parsing](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns) in Oracle Java documentation.
+    #
+    # For more information about CQL date, time and timestamp literals, see [Date, time, and timestamp format](https://docs.datastax.com/en/dse/6.0/cql/cql/cql_reference/refDateTimeFormats.html?hl=timestamp).
+    time = "ISO_LOCAL_TIME"
+
+    # This setting is used in the following situations:
+    #
+    # - When the target column is of CQL `timestamp` type, or when loading data through a `USING TIMESTAMP` clause, or when unloading data from a `writetime()` function call, and if `codec.timestamp` is set to `UNITS_SINCE_EPOCH`, then the time unit specified here is used to convert numeric data to and from temporals. For example, if the input is 123 and the time unit specified here is SECONDS, then the input will be interpreted as 123 seconds since `codec.epoch`.
+    # - When loading, and the target CQL type is numeric, but the input is alphanumeric and represents a temporal literal, the time unit specified here will be used to convert the parsed temporal into a numeric value. For example, if the input is `2018-12-10T19:32:45Z` and the time unit specified here is SECONDS, then the parsed temporal will be converted into seconds since `codec.epoch`.
+    #
+    # All `TimeUnit` enum constants are valid choices.
+    unit = MILLISECONDS
+
+    # This setting is used in the following situations:
+    #
+    # - When the target column is of CQL `timestamp` type, or when loading to a `USING TIMESTAMP` clause, or when unloading from a `writetime()` function call, and if `codec.timestamp` is set to `UNITS_SINCE_EPOCH`, then the epoch specified here determines the relative point in time to use to convert numeric data to and from temporals. For example, if the input is 123 and the epoch specified here is `2000-01-01T00:00:00Z`, then the input will be interpreted as N `codec.unit`s since January 1st 2000.
+    # - When loading, and the target CQL type is numeric, but the input is alphanumeric and represents a temporal literal, the time unit specified here will be used to convert the parsed temporal into a numeric value. For example, if the input is `2018-12-10T19:32:45Z` and the epoch specified here is `2000-01-01T00:00:00Z`, then the parsed timestamp will be converted to N `codec.unit`s since January 1st 2000.
+    # - When parsing temporal literals, if the input does not contain a date part, then the date part of the instant specified here will be used instead. For example, if the input is `19:32:45` and the epoch specified here is `2000-01-01T00:00:00Z`, then the input will be interpreted `2000-01-01T19:32:45Z`.
+    #
+    # The value must be expressed in [`ISO_ZONED_DATE_TIME`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_ZONED_DATE_TIME) format.
+    epoch = "1970-01-01T00:00:00Z"
+
+    # Strategy to use when generating time-based (version 1) UUIDs from timestamps. Clock sequence and node ID parts of generated UUIDs are determined on a best-effort basis and are not fully compliant with RFC 4122. Valid values are:
+    #
+    # - RANDOM: Generates UUIDs using a random number in lieu of the local clock sequence and node ID. This strategy will ensure that the generated UUIDs are unique, even if the original timestamps are not guaranteed to be unique.
+    # - FIXED: Preferred strategy if original timestamps are guaranteed unique, since it is faster. Generates UUIDs using a fixed local clock sequence and node ID.
+    # - MIN: Generates the smallest possible type 1 UUID for a given timestamp. Warning: this strategy doesn't guarantee uniquely generated UUIDs and should be used with caution.
+    # - MAX: Generates the biggest possible type 1 UUID for a given timestamp. Warning: this strategy doesn't guarantee uniquely generated UUIDs and should be used with caution.
+    uuidStrategy = RANDOM
+
+    # Strategy to use when converting binary data to strings. Only applicable when unloading columns of CQL type `blob`, or columns of geometry types, if the value of `codec.geo` is `WKB`; and only if the connector in use requires stringification. Valid values are:
+    #
+    # - BASE64: Encode the binary data into a Base-64 string. This is the default strategy.
+    # - HEX: Encode the binary data as CQL blob literals. CQL blob literals follow the general syntax: `0[xX][0-9a-fA-F]+`, that is, `0x` followed by hexadecimal characters, for example: `0xcafebabe`. This format produces lengthier strings than BASE64, but is also the only format compatible with CQLSH.
+    binary = BASE64
+
+    # Strategy to use when converting geometry types to strings. Geometry types are only available in DataStax Enterprise (DSE) 5.0 or higher. Only applicable when unloading columns of CQL type `Point`, `LineString` or `Polygon`, and only if the connector in use requires stringification. Valid values are:
+    #
+    # - WKT: Encode the data in Well-known text format. This is the default strategy.
+    # - WKB: Encode the data in Well-known binary format. The actual encoding will depend on the value chosen for the `codec.binary` setting (HEX or BASE64).
+    # - JSON: Encode the data in GeoJson format.
+    geo = WKT
+  }
+
+  # Monitoring-specific settings.
+  monitoring {
+
+    # The report interval. DSBulk will print useful metrics about the ongoing operation at this rate; for example, if this value is set to 10 seconds, then DSBulk will print metrics every ten seconds. Valid values: any value specified in [HOCON duration syntax](https://github.com/lightbend/config/blob/master/HOCON.md#duration-format), but durations lesser than one second will be rounded up to 1 second.
+    reportRate = 5 seconds
+
+    # The time unit used when printing throughput rates. For example, if this unit is SECONDS, then the throughput will be displayed in rows per second. Valid values: all `TimeUnit` enum constants.
+    rateUnit = SECONDS
+
+    # The time unit used when printing latency durations. For example, if this unit is MILLISECONDS, then the latencies will be displayed in milliseconds. Valid values: all `TimeUnit` enum constants.
+    durationUnit = MILLISECONDS
+
+    # The expected total number of writes. Optional, but if set, the console reporter will also print the overall achievement percentage. Setting this value to `-1` disables this feature.
+    expectedWrites = -1
+
+    # The expected total number of reads. Optional, but if set, the console reporter will also print the overall achievement percentage. Setting this value to `-1` disables this feature.
+    expectedReads = -1
+
+    # Whether or not to track the throughput in bytes. When enabled, DSBulk will track and display the number of bytes sent or received per second. While useful to evaluate how much data is actually being transferred, computing such metrics is CPU-intensive and may slow down the operation. This is why it is disabled by default. Also note that the heuristic used to compute data sizes is not 100% accurate and sometimes underestimates the actual size.
+    trackBytes = false
+
+    # Enable or disable JMX reporting. Note that to enable remote JMX reporting, several properties must also be set in the JVM during launch. This is accomplished via the `DSBULK_JAVA_OPTS` environment variable.
+    #
+    # Driver metrics can also be exposed; note however that by default, all driver metrics are disabled. You can enable them with the following driver settings:
+    # - `datastax-java-driver.advanced.metrics.session.enabled` should contain a list of session-level metric names to enable;
+    # - `datastax-java-driver.advanced.metrics.node.enabled` should contain a list of node-level metric names to enable.
+    # Driver metrics appear under a folder named after the session name (by default in DSBulk, the session name is simply "driver").
+    jmx = true
+
+    # Enable or disable CSV reporting. If enabled, CSV files containing metrics will be generated in the designated log directory. Driver metrics can also be exported, but they are disabled by default; see `monitoring.jmx` for details for details about how to enable them.
+    csv = false
+
+    # Enable or disable console reporting. If enabled, DSBulk will print useful metrics about the ongoing operation to standard error; the metrics will be refreshed at `reportRate`. Displayed information includes: total records, failed records, throughput, latency, and if available, average batch size. Note that when `log.verbosity` is set to quiet (0), DSBulk will disable the console reporter regardless of the value specified here. The default is true (print ongoing metrics to the console).
+    console = true
+
+    # Settings related to Prometheus.
+    prometheus {
+
+      # Settings related to scraping (pulling metrics from DSBulk while the operation is running). This is most suitable to monitor DSBulk's performance while the operation is being carried out. Note that when scraping, it is usually not possible to see final stats in Prometheus, as the most recent stats correspond to the last scrape, which may have happened before the operation finished.
+      pull {
+
+        # Enable or disable exposing metrics to Prometheus in the traditional pull model (scraping). If enabled, all DSBulk and metrics will be accessible at an (unsecured) HTTP endpoint. Driver metrics can also be exported, but they are disabled by default; see `monitoring.jmx` for details about how to enable them.
+        enabled = false
+
+        # The hostname that the metrics HTTP server should bind to. Leave empty to have the server bind to the wildcard address (0.0.0.0).
+        hostname = ""
+
+        # The port that the metrics HTTP server should bind to.
+        port = 8080
+
+      }
+
+      # Settings related to pushing DSBulk metrics to Prometheus via a PushGateway. This is most suitable to record the outcome of a DSBulk operation after it finished. See https://github.com/prometheus/pushgateway for details.
+      push {
+
+        # Enabled or disable pushing metrics to a PushGateway. If enabled, DSBulk will push metrics to this URL at the end of the operation. Note that not all metrics are exported when pushing to a PushGateway; only some high-level ones are, including the total time elapsed, the number of records processed and the number of rows written or read. In particular, driver metrics are currently not pushed.
+        enabled = false
+
+        # The base URL of a Prometheus PushGateway server, e.g. http://pushgateway.example.org:9091 (don't include the "/metrics" path).
+        url = "http://localhost:9091"
+
+        # The username to authenticate against the push gateway, using basic HTTP auth. Leave empty to use unautheticated HTTP requests.
+        username = ""
+
+        # The password to authenticate against the push gateway, using basic HTTP auth. Leave empty to use unautheticated HTTP requests.
+        password = ""
+
+        # Group-By keys to use when pushing metrics.
+        groupBy {
+
+          # Whether to add an instance grouping key to exported metrics. If enabled, DSBulk adds an "instance" grouping key with its value set to the machine's IP address to the exported metrics. This will effectively group metrics by instance, rather than by job. See https://github.com/prometheus/pushgateway#about-the-job-and-instance-labels for more information.
+          instance = false
+
+          # Whether to add the operation ID as a grouping key to exported metrics. If enabled, DSBulk adds an "operation_id" grouping key with its value set to the current operation ID (see `engine.executionId`) to the exported metrics. This will effectively group metrics by operation, rather than by job.
+          operation = false
+
+          # A set of static extra keys to add to the grouping keys. Note that grouping keys are also added as labels to each exported metric in push mode.
+          # @leaf
+          # @type map<string,string>
+          keys = {}
+
+        }
+      }
+
+      # The job name to use. DSBulk will add a label "job" with this value to each exported metric. This is also the job name used when pushing metrics to a PushGateway. The default is "DSBulk". See https://github.com/prometheus/pushgateway#about-the-job-and-instance-labels for more information.
+      job = DSBulk
+
+      # A set of static labels to add to each exported metric, in both pull and push modes. Note that DSBulk automatically adds the following labels:
+      #
+      # - `operation_id` is set to the current operation ID (a.k.a. execution ID, see `engine.executionId`);
+      # - `job` is set to the job name (as defined by `monitoring.prometheus.job`, by default "DSBulk");
+      # - `application_name` is set to "DataStax Bulk Loader" followed by the operation ID;
+      # - `application_version` is set to the DSBulk's version;
+      # - `driver_version` is set to the DataStax Java driver version;
+      # - `client_id` is set to DSBulk's client UUID.
+      #
+      # The last four labels correspond to values that DSBulk also passes to the driver, which in turn uses the same info to connect to Cassandra. This makes it possible to correlate data sent by the driver to Cassandra with data sent by DSBulk to Prometheus.
+      # @leaf
+      # @type map<string,string>
+      labels = {}
+
+    }
+
+  }
+
+  # Schema-specific settings.
+  schema {
+
+    # Keyspace used for loading or unloading data. Keyspace names should not be quoted and are case-sensitive. `MyKeyspace` will match a keyspace named `MyKeyspace` but not `mykeyspace`. Either `keyspace` or `graph` is required if `query` is not specified or is not qualified with a keyspace name.
+    # @type string
+    keyspace: null
+
+    # Graph name used for loading or unloading graph data. This option can only be used for modern graphs created with the Native engine (DSE 6.8+). Graph names should not be quoted and are case-sensitive. `MyGraph` will match a graph named `MyGraph` but not `mygraph`. Either `keyspace` or `graph` is required if `query` is not specified or is not qualified with a keyspace name.
+    # @type string
+    graph: null
+
+    # Table used for loading or unloading data. Table names should not be quoted and are case-sensitive. `MyTable` will match a table named `MyTable` but not `mytable`. Either `table`, `vertex` or `edge` is required if `query` is not specified.
+    # @type string
+    table: null
+
+    # Vertex label used for loading or unloading graph data. This option can only be used for modern graphs created with the Native engine (DSE 6.8+). The vertex label must correspond to an existing table created with the `WITH VERTEX LABEL` option. Vertex labels should not be quoted and are case-sensitive. `MyVertex` will match a label named `MyVertex` but not `myvertex`. Either `table`, `vertex` or `edge` is required if `query` is not specified.
+    # @type string
+    vertex: null
+
+    # Edge label used for loading or unloading graph data. This option can only be used for modern graphs created with the Native engine (DSE 6.8+). The edge label must correspond to an existing table created with the `WITH EDGE LABEL` option; also, when `edge` is specified, then `from` and `to` must be specified as well. Edge labels should not be quoted and are case-sensitive. `MyEdge` will match a label named `MyEdge` but not `myedge`. Either `table`, `vertex` or `edge` is required if `query` is not specified.
+    # @type string
+    edge: null
+
+    # The name of the edge's incoming vertex label, for loading or unloading graph data. This option can only be used for modern graphs created with the Native engine (DSE 6.8+). This option is mandatory when `edge` is specified; ignored otherwise. Vertex labels should not be quoted and are case-sensitive. `MyVertex` will match a label named `MyVertex` but not `myvertex`.
+    # @type string
+    from: null
+
+    # The name of the edge's outgoing vertex label, for loading or unloading graph data. This option can only be used for modern graphs created with the Native engine (DSE 6.8+). This option is mandatory when `edge` is specified; ignored otherwise. Vertex labels should not be quoted and are case-sensitive. `MyVertex` will match a label named `MyVertex` but not `myvertex`.
+    # @type string
+    to: null
+
+    # The query to use. If not specified, then *schema.keyspace* and *schema.table* must be specified, and dsbulk will infer the appropriate statement based on the table's metadata, using all available columns. If `schema.keyspace` is provided, the query need not include the keyspace to qualify the table reference.
+    #
+    # For loading, the statement can be any `INSERT`, `UPDATE` or `DELETE` statement. `INSERT` statements are preferred for most load operations, and bound variables should correspond to mapped fields; for example, `INSERT INTO table1 (c1, c2, c3) VALUES (:fieldA, :fieldB, :fieldC)`. `UPDATE` statements are required if the target table is a counter table, and the columns are updated with incremental operations (`SET col1 = col1 + :fieldA` where `fieldA` is a field in the input data). A `DELETE` statement will remove existing data during the load operation.
+    #
+    # For unloading and counting, the statement can be any regular `SELECT` statement. If the statement does not contain any WHERE, ORDER BY, GROUP BY, or LIMIT clause, the engine will generate a token range restriction clause of the form: `WHERE token(...) > :start and token(...) <= :end` and will generate range read statements, thus allowing parallelization of reads while at the same time targeting coordinators that are also replicas (see schema.splits). If the statement does contain WHERE, ORDER BY, GROUP BY or LIMIT clauses however, the query will be executed as is; the engine will only be able to parallelize the operation if the query includes a WHERE clause including the following relations: `token(...) > :start AND token(...) <= :end` (the bound variables can have any name). Note that, unlike LIMIT clauses, PER PARTITION LIMIT clauses can be parallelized.
+    #
+    # Statements can use both named and positional bound variables. Named bound variables should be preferred, unless the protocol version in use does not allow them; they usually have names matching those of the columns in the destination table, but this is not a strict requirement; it is, however, required that their names match those of fields specified in the mapping. Positional variables can also be used, and will be named after their corresponding column in the destination table.
+    #
+    # When loading and unloading graph data, the query must be provided in plain CQL; Gremlin queries are not supported.
+    #
+    # Note: The query is parsed to discover which bound variables are present, and to map the variables correctly to fields.
+    #
+    # See *mapping* setting for more information.
+    # @type string
+    query: null
+
+    # Specify whether to map `null` input values to "unset" in the database, i.e., don't modify a potentially pre-existing value of this field for this row. Valid for load scenarios, otherwise ignore. Note that setting to false creates tombstones to represent `null`.
+    #
+    # Note that this setting is applied after the *codec.nullStrings* setting, and may intercept `null`s produced by that setting.
+    #
+    # This setting is ignored when counting. When set to true but the protocol version in use does not support unset values (i.e., all protocol versions lesser than 4), this setting will be forced to false and a warning will be logged.
+    nullToUnset: true
+
+    # The field-to-column mapping to use, that applies to both loading and unloading; ignored when counting. If not specified, the loader will apply a strict one-to-one mapping between the source fields and the database table. If that is not what you want, then you must supply an explicit mapping. Mappings should be specified as a map of the following form:
+    #
+    # - Indexed data sources: `0 = col1, 1 = col2, 2 = col3`, where `0`, `1`, `2`, are the zero-based indices of fields in the source data; and `col1`, `col2`, `col3` are bound variable names in the insert statement.
+    #     - A shortcut to map the first `n` fields is to simply specify the destination columns: `col1, col2, col3`.
+    # - Mapped data sources: `fieldA = col1, fieldB = col2, fieldC = col3`, where `fieldA`, `fieldB`, `fieldC`, are field names in the source data; and `col1`, `col2`, `col3` are bound variable names in the insert statement.
+    #     - A shortcut to map fields named like columns is to simply specify the destination columns: `col1, col2, col3`.
+    #
+    # To specify that a field should be used as the timestamp (a.k.a. write-time) or ttl (a.k.a. time-to-live) of the inserted row, use the specially named fake columns `__ttl` and `__timestamp`: `fieldA = __timestamp, fieldB = __ttl`. Note that Timestamp fields are parsed as regular CQL timestamp columns and must comply with either `codec.timestamp`, or alternatively, with `codec.unit` + `codec.epoch`. TTL fields are parsed as integers representing durations in seconds, and must comply with `codec.number`.
+    #
+    # To specify that a column should be populated with the result of a function call, specify the function call as the input field (e.g. `now() = c4`). Note, this is only relevant for load operations. Similarly, to specify that a field should be populated with the result of a function call, specify the function call as the input column (e.g. `field1 = now()`). This is only relevant for unload operations. Function calls can also be qualified by a keyspace name: `field1 = ks1.max(c1,c2)`.
+    #
+    # In addition, for mapped data sources, it is also possible to specify that the mapping be partly auto-generated and partly explicitly specified. For example, if a source row has fields `c1`, `c2`, `c3`, and `c5`, and the table has columns `c1`, `c2`, `c3`, `c4`, one can map all like-named columns and specify that `c5` in the source maps to `c4` in the table as follows: `* = *, c5 = c4`.
+    #
+    # One can specify that all like-named fields be mapped, except for `c2`: `* = -c2`. To skip `c2` and `c3`: `* = [-c2, -c3]`.
+    #
+    # Any identifier, field or column, that is not strictly alphanumeric (i.e. not matching `[a-zA-Z0-9_]+`) must be surrounded by double-quotes, just like you would do in CQL: `"Field ""A""" = "Column 2"` (to escape a double-quote, simply double it). Note that, contrary to the CQL grammar, unquoted identifiers will not be lower-cased: an identifier such as `MyColumn1` will match a column named `"MyColumn1"` and not `mycolumn1`.
+    #
+    # The exact type of mapping to use depends on the connector being used. Some connectors can only produce indexed records; others can only produce mapped ones, while others are capable of producing both indexed and mapped records at the same time. Refer to the connector's documentation to know which kinds of mapping it supports.
+    # @type string
+    mapping: null
+
+    # Specify whether or not to accept records that contain extra fields that are not declared in the mapping. For example, if a record contains three fields A, B, and C, but the mapping only declares fields A and B, then if this option is true, C will be silently ignored and the record will be considered valid, and if false, the record will be rejected. This setting also applies to user-defined types and tuples. Only applicable for loading, ignored otherwise.
+    #
+    # This setting is ignored when counting.
+    allowExtraFields = true
+
+    # Specify whether or not to accept records that are missing fields declared in the mapping. For example, if the mapping declares three fields A, B, and C, but a record contains only fields A and B, then if this option is true, C will be silently assigned null and the record will be considered valid, and if false, the record will be rejected. If the missing field is mapped to a primary key column, the record will always be rejected, since the database will reject the record. This setting also applies to user-defined types and tuples. Only applicable for loading, ignored otherwise.
+    #
+    # This setting is ignored when counting.
+    allowMissingFields = false
+
+    # The Time-To-Live (TTL) of inserted/updated cells during load (seconds); a value of -1 means there is no TTL. Not applicable to unloading nor counting. Ignored when `schema.query` is provided. For more information, see the [CQL Reference](https://docs.datastax.com/en/dse/6.0/cql/cql/cql_reference/cql_commands/cqlInsert.html#cqlInsert__ime-value), [Setting the time-to-live (TTL) for value](http://docs.datastax.com/en/dse/6.0/cql/cql/cql_using/useTTL.html), and [Expiring data with time-to-live](http://docs.datastax.com/en/dse/6.0/cql/cql/cql_using/useExpire.html).
+    queryTtl = -1
+
+    # The timestamp of inserted/updated cells during load; otherwise, the current time of the system running the tool is used. Not applicable to unloading nor counting. Ignored when `schema.query` is provided. The value must be expressed in the timestamp format specified by the `codec.timestamp` setting.
+    #
+    # Query timestamps for Cassandra have microsecond resolution; any sub-microsecond information specified is lost. For more information, see the [CQL Reference](https://docs.datastax.com/en/dse/6.0/cql/cql/cql_reference/cql_commands/cqlInsert.html#cqlInsert__timestamp-value).
+    # @type string
+    queryTimestamp = null
+
+    # Whether to preserve cell timestamps when loading and unloading. Ignored when `schema.query` is provided, or when the target table is a counter table. If true, the following rules will be applied to generated queries:
+    #
+    # - When loading, instead of a single INSERT statement, the generated query will be a BATCH query; this is required in order to preserve individual column timestamps for each row.
+    # - When unloading, the generated SELECT statement will export each column along with its individual timestamp.
+    #
+    # For both loading and unlaoding, DSBulk will import and export timestamps using field names such as `"writetime(<column>)"`, where `<column>` is the column's internal CQL name; for example, if the table has a column named `"MyCol"`, its corresponding timestamp would be exported as `"writetime(MyCol)"` in the generated query and in the resulting connector record. If you intend to use this feature to export and import tables letting DSBulk generate the appropriate queries, these names are fine and need not be changed. If, however, you would like to export or import data to or from external sources that use different field names, you could do so by using the function `writetime` in a schema.mapping entry; for example, the following mapping would map `col1` along with its timestamp to two distinct fields, `field1` and `field1_writetime`: `field1 = col1, field1_writetime = writetime(col1)`.
+    preserveTimestamp = false
+
+    # Whether to preserve cell TTLs when loading and unloading. Ignored when `schema.query` is provided, or when the target table is a counter table. If true, the following rules will be applied to generated queries:
+    #
+    # - When loading, instead of a single INSERT statement, the generated query will be a BATCH query; this is required in order to preserve individual column TTLs for each row.
+    # - When unloading, the generated SELECT statement will export each column along with its individual TTL.
+    #
+    # For both loading and unlaoding, DSBulk will import and export TTLs using field names such as `"ttl(<column>)"`, where `<column>` is the column's internal CQL name; for example, if the table has a column named `"MyCol"`, its corresponding TTL would be exported as `"ttl(MyCol)"` in the generated query and in the resulting connector record. If you intend to use this feature to export and import tables letting DSBulk generate the appropriate queries, these names are fine and need not be changed. If, however, you would like to export or import data to or from external sources that use different field names, you could do so by using the function `ttl` in a schema.mapping entry; for example, the following mapping would map `col1` along with its TTL to two distinct fields, `field1` and `field1_ttl`: `field1 = col1, field1_ttl = ttl(col1)`.
+    preserveTtl = false
+
+    # The number of token range splits in which to divide the token ring. In other words, this setting determines how many read requests will be generated in order to read an entire table. Only used when unloading and counting; ignored otherwise. Note that the actual number of splits may be slightly greater or lesser than the number specified here, depending on the actual cluster topology and token ownership. Also, it is not possible to generate fewer splits than the total number of primary token ranges in the cluster, so the actual number of splits is always equal to or greater than that number. Set this to higher values if you experience timeouts when reading from the database, specially if paging is disabled. This setting should also be greater than `engine.maxConcurrentQueries`. The special syntax `NC` can be used to specify a number that is a multiple of the number of available cores, e.g. if the number of cores is 8, then 0.5C = 0.5 * 8 = 4 splits.
+    splits = 8C
+
+  }
+
+  # Connector-specific settings. This section contains settings for the connector to use; it also contains sub-sections, one for each available connector.
+  #
+  # This setting is ignored when counting.
+  connector {
+
+    # The name of the connector to use.
+    name = "csv"
+
+  }
+
+  # Batch-specific settings.
+  #
+  # These settings control how the workflow engine groups together statements before writing them.
+  #
+  # Only applicable for loading.
+  batch {
+
+    # The grouping mode. Valid values are:
+    # - `DISABLED`: batching is disabled.
+    # - `PARTITION_KEY`: groups together statements that share the same partition key. This is usually the most performant mode; however it may not work at all if the dataset is unordered, i.e., if partition keys appear randomly and cannot be grouped together.
+    # - `REPLICA_SET`: groups together statements that share the same replica set. This mode works in all cases, but may incur in some throughput and latency degradation, specially with large clusters or high replication factors.
+    # When tuning DSBulk for batching, the recommended approach is as follows:
+    # 1. Start with `PARTITION_KEY`;
+    # 2. If the average batch size is close to 1, try increasing `bufferSize`;
+    # 3. If increasing `bufferSize` doesn't help, switch to `REPLICA_SET` and set `maxBatchStatements` or `maxSizeInBytes` to low values to avoid timeouts or errors;
+    # 4. Increase `maxBatchStatements` or `maxSizeInBytes` to get the best throughput while keeping latencies acceptable.
+    # The default is `PARTITION_KEY`.
+    mode = PARTITION_KEY
+
+    # **DEPRECATED**. Use `maxBatchStatements` instead.
+    # @type number
+    maxBatchSize = null
+
+    # The maximum number of statements that a batch can contain. The ideal value depends on two factors:
+    # - The data being loaded: the larger the data, the smaller the batches should be.
+    # - The batch mode: when `PARTITION_KEY` is used, larger batches are acceptable, whereas when `REPLICA_SET` is used, smaller batches usually perform better. Also, when using `REPLICA_SET`, it is preferrable to keep this number below the threshold configured server-side for the setting `unlogged_batch_across_partitions_warn_threshold` (the default is 10); failing to do so is likely to trigger query warnings (see `log.maxQueryWarnings` for more information).
+    # When set to a value lesser than or equal to zero, the maximum number of statements is considered unlimited. At least one of `maxBatchStatements` or `maxSizeInBytes` must be set to a positive value when batching is enabled.
+    maxBatchStatements = 32
+
+    # The maximum data size that a batch can hold. This is the number of bytes required to encode all the data to be persisted, without counting the overhead generated by the native protocol (headers, frames, etc.).
+    #
+    # The value specified here should be lesser than or equal to the value that has been configured server-side for the option `batch_size_fail_threshold_in_kb` in cassandra.yaml, but note that the heuristic used to compute data sizes is not 100% accurate and sometimes underestimates the actual size. See the documentation for the [cassandra.yaml configuration file](https://docs.datastax.com/en/dse/6.0/dse-dev/datastax_enterprise/config/configCassandra_yaml.html#configCassandra_yaml__advProps) for more information.
+    #
+    # When set to a value lesser than or equal to zero, the maximum data size is considered unlimited. At least one of `maxBatchStatements` or `maxSizeInBytes` must be set to a positive value when batching is enabled.
+    #
+    # Values for this option should either be valid long integers, or use HOCON's [size-in-bytes](https://github.com/lightbend/config/blob/master/HOCON.md#size-in-bytes-format) format, e.g. `1234`, `1K` or `5 kibibytes`.
+    maxSizeInBytes = -1
+
+    # The buffer size to use for flushing batched statements. Should be set to a multiple of `maxBatchStatements`, e.g. 2 or 4 times that value; higher values consume more memory and usually do not incur in any noticeable performance gain. When set to a value lesser than or equal to zero, the buffer size is implicitly set to 4 times `maxBatchStatments`.
+    bufferSize = -1
+
+  }
+
+  # Settings applicable for the count workflow, ignored otherwise.
+  stats {
+
+    # Which kind(s) of statistics to compute. Only applicaple for the count workflow, ignored otherwise. Possible values are:
+    # * `global`: count the total number of rows in the table.
+    # * `ranges`: count the total number of rows per token range in the table.
+    # * `hosts`: count the total number of rows per hosts in the table.
+    # * `partitions`: count the total number of rows in the N biggest partitions in the table. When using this mode, you can chose how many partitions to track with the `numPartitions` setting.
+    modes = [global]
+
+    # The number of distinct partitions to count rows for. Only applicaple for the count workflow when `stats.modes` contains `partitions`, ignored otherwise.
+    numPartitions = 10
+
+  }
+
+  # Executor-specific settings. Executor settings control how the DataStax Java driver is used by DSBulk, and notably, the desired amount of driver-level concurrency and throughput. These settings are for advanced users.
+  executor {
+
+    # The maximum number of "in-flight" queries, or maximum number of concurrent requests waiting for a response from the server. When writing to the database, batch statements count as one request. When reading from the database, each request for the next pages count as one request.
+    #
+    # This acts as a safeguard to prevent overloading the cluster. Reduce this value when the throughput for reads and writes cannot match the throughput of connectors, and latencies get too high; this is usually a sign that the workflow engine is not well calibrated and will eventually run out of memory, or some queries will timeout.
+    #
+    # This setting applies a "soft" limit to the gloabl throughput, without capping it at a fixed value. If you need a fixed maximum throughput, you should use `maxPerSecond` instead.
+    #
+    # Note that this setting is implemented by a semaphore and may block application threads if there are too many in-flight requests.
+    #
+    # Setting this option to any negative value or zero will disable it.
+    maxInFlight = -1
+
+    # The maximum number of concurrent operations per second. When writing to the database, this means the maximum number of writes per second (batch statements are counted by the number of statements included); when reading from the database, this means the maximum number of rows per second.
+    #
+    # This acts as a safeguard to prevent overloading the cluster. Reduce this value when the throughput for reads and writes cannot match the throughput of connectors, and latencies get too high; this is usually a sign that the workflow engine is not well calibrated and will eventually run out of memory, or some queries will timeout.
+    #
+    # When connecting to DataStax Astra clusters, a rate limit is always enforced. By default, the limit is 4,096 operations per second and per coordinator; therefore, if no rate limit is set, and the cluster is an Astra cluster, DSBulk will automatically apply an appropriate limit and log a message.
+    #
+    # This setting applies a "hard" limit to the gloabl throughput, capping it at a fixed value. If you need a a soft throughput limit, you should use `maxInFlight` instead.
+    #
+    # Note that this setting is implemented by a semaphore and may block application threads if there are too many in-flight requests.
+    #
+    # Setting this option to any negative value or zero will disable it.
+    maxPerSecond = -1
+
+    # The maximum number of bytes per second. When writing to the database, this means the maximum number of bytes written per second; when reading from the database, this means the maximum number of bytes read per second.
+    #
+    # This acts as a safeguard to prevent overloading the cluster. Reduce this value when the throughput for reads and writes cannot match the throughput of connectors, and latencies get too high; this is usually a sign that the workflow engine is not well calibrated and will eventually run out of memory, or some queries will timeout.
+    #
+    # This setting applies a "hard" limit to the gloabl throughput, capping it at a fixed value. If you need a a soft throughput limit, you should use `maxInFlight` instead.
+    #
+    # Note that this setting is implemented by a semaphore and may block application threads if there are too many in-flight requests.
+    #
+    # Setting this option to any negative value or zero will disable it.
+    #
+    # Values for this option should either be valid long integers, or use HOCON's [size-in-bytes](https://github.com/lightbend/config/blob/master/HOCON.md#size-in-bytes-format) format, e.g. `1234`, `1K` or `5 kibibytes`.
+    maxBytesPerSecond = -1
+
+    # Continuous-paging specific settings.
+    #
+    # Only applicable for unloads, and only if this feature is available in the remote cluster, ignored otherwise.
+    #
+    # This section is deprecated except for `continuousPaging.enabled`. Please configure other continuous paging options (such as page size, maximum pages, etc.) directly in the driver configuration section. See [DSE continuous paging tuning and support guide](https://www.datastax.com/blog/2017/04/dse-continuous-paging-tuning-and-support-guide) for more information.
+    continuousPaging {
+
+      # Enable or disable continuous paging. If the target cluster does not support continuous paging or if `driver.query.consistency` is not `ONE` or `LOCAL_ONE`, traditional paging will be used regardless of this setting.
+      enabled = true
+
+      # The unit to use for the `pageSize` setting. Possible values are: `ROWS`, `BYTES`.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.continuous-paging.page-size-in-bytes` instead.
+      pageUnit = ROWS
+
+      # The size of the page. The unit to use is determined by the `pageUnit` setting. The ideal page size depends on the size of the rows being unloaded: larger page sizes may have a positive impact on throughput for small rows, and vice versa.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.continuous-paging.page-size` instead.
+      pageSize = 5000
+
+      # The maximum number of pages to retrieve. Setting this value to zero retrieves all pages available.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.continuous-paging.max-pages` instead.
+      maxPages = 0
+
+      # The maximum number of pages per second. Setting this value to zero indicates no limit.
+      #
+      # **DEPRECATED**. Use `datastax-java-driver.advanced.continuous-paging.max-pages-per-second` instead.
+      maxPagesPerSecond = 0
+
+      # The maximum number of concurrent continuous paging queries that should be carried in parallel. Set this number to a value equal to or lesser than the value configured server-side for `continuous_paging.max_concurrent_sessions` in the cassandra.yaml configuration file (60 by default); otherwise some requests might be rejected. Settting this option to any negative value or zero will disable it.
+      #
+      # **DEPRECATED**: use `engine.maxConcurrentQueries` instead.
+      maxConcurrentQueries = 60
+    }
+
+  }
+
+  # Engine-specific settings. Engine settings control how workflows are configured, and notably, what is their execution ID, whether they should run in Dry-run mode, and the desired amount of concurrency.
+  engine {
+
+    # Enable or disable dry-run mode, a test mode that runs the command but does not load data. Not applicable for unloading nor counting.
+    dryRun = false
+
+    # A unique identifier to attribute to each execution. When unspecified or empty, the engine will automatically generate identifiers of the following form: *workflow*_*timestamp*, where :
+    #
+    # - *workflow* stands for the workflow type (`LOAD`, `UNLOAD`, etc.);
+    # - *timestamp* is the current timestamp formatted as `uuuuMMdd-HHmmss-SSSSSS` (see [https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns)) in UTC, with microsecond precision if available, and millisecond precision otherwise.
+    #
+    # When this identifier is user-supplied, it is important to guarantee its uniqueness; failing to do so may result in execution failures. It is also possible to provide templates here. Any format compliant with the formatting rules of [`String.format()`](https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#syntax) is accepted, and can contain the following parameters:
+    #
+    # - `%1$s` : the workflow type (`LOAD`, `UNLOAD`, etc.);
+    # - `%2$t` : the current time (with microsecond precision if available, and millisecond precision otherwise);
+    # - `%3$s` : the JVM process PID (this parameter might not be available on some operating systems; if its value cannot be determined, a random integer will be inserted instead).
+    # @type string
+    executionId = null
+
+    # The maximum number of concurrent queries that should be carried in parallel.
+    #
+    # This acts as a safeguard to prevent more queries executing in parallel than the cluster can handle, or to regulate throughput when latencies get too high. Batch statements count as one query.
+    #
+    # When using continuous paging, also make sure to set this number to a value equal to or lesser than the number of nodes in the local datacenter multiplied by the value configured server-side for `continuous_paging.max_concurrent_sessions` in the cassandra.yaml configuration file (60 by default); otherwise some requests might be rejected.
+    #
+    # The special syntax `NC` can be used to specify a number that is a multiple of the number of available cores, e.g. if the number of cores is 8, then 0.5C = 0.5 * 8 = 4 concurrent queries.
+    #
+    # The default value is 'AUTO'; with this special value, DSBulk will optimize the number of concurrent queries according to the number of available cores, and the operation being executed. The actual value usually ranges from the number of cores to eight times that number.
+    maxConcurrentQueries = AUTO
+
+    # Specify whether DSBulk should use data size sampling to optimize its execution engine. Only applicable for loading, ignored otherwise.
+    #
+    # Data size sampling is done by reading a few records from the connector; in this case, the connector will be invoked twice: once to sample the data size, then again to read the entire data. This is only possible if the data source can be rewinded and read again from the beginning. If your data source does not support this – for example, because it can only be read once – then you should set this option to false.
+    #
+    # Note that when loading from standard input, DSBulk will never perform data size sampling, regardless of the value set here.
+    #
+    # The default value is 'true', meaning that data size sampling is enabled.
+    dataSizeSamplingEnabled = true
+  }
+
+  # Runner-specific settings. Runner settings control how DSBulk parses command lines and reads its configuration.
+  runner {
+
+    # Whether to prompt for passwords when they are missing from configuration files. When this option is true (the default value), if a login or username is present in the configuration, but not its corresponding password, DSBulk will prompt for it.
+    #
+    # Prompting from passwords require interactive shells; if the standard input is not connected to a terminal, no passwords will be prompted, even if this option is true. You should only disable this feature if DSBulk mistankenly assumes that it is running in an interactive shell.
+    promptForPasswords = true
+
+  }
+
+  # Settings applicable for reading from AWS S3 URLs.
+  s3 {
+    # The size (count) of the S3Client cache. Since each S3 URL
+    # must contain the credentials for the target bucket, we cache
+    # the clients to prevent rebuilding the same client over and over.
+    # The default size of 20 is totally arbitrary, as we generally
+    # expect that most S3 URLs in a given batch will be using the
+    # same credentials, meaning the cache will really only ever
+    # contain one entry.
+    clientCacheSize = 20
+  }
+
+  # This group of settings is purely internal and is the interface for
+  # DSBulk's infrastructure to customize how some settings are exposed to the user.
+  #
+  # In particular, how settings are documented and shortcut options that map to
+  # settings that are commonly specified in the command line.
+  metaSettings {
+
+    # Specify how settings should be prioritized in generated docs and help.
+    # Common and preferred settings must be fully qualified, i.e., start with "dsbulk."
+    docHints {
+      commonSettings = [
+        # Driver common settings
+        datastax-java-driver.basic.contact-points,
+        datastax-java-driver.basic.default-port,
+        datastax-java-driver.basic.cloud.secure-connect-bundle,
+        datastax-java-driver.advanced.auth-provider.username,
+        datastax-java-driver.advanced.auth-provider.password,
+        datastax-java-driver.basic.request.consistency,
+        datastax-java-driver.basic.load-balancing-policy.local-datacenter,
+        # DSBulk common settings
+        dsbulk.schema.keyspace,
+        dsbulk.schema.table,
+        dsbulk.schema.mapping,
+        dsbulk.engine.dryRun,
+        dsbulk.engine.maxConcurrentQueries,
+        dsbulk.log.maxErrors,
+        dsbulk.log.directory,
+        dsbulk.log.verbosity,
+        dsbulk.monitoring.reportRate
+      ]
+      preferredSettings = [
+      ]
+    }
+
+    # Specify shortcuts for "long" options.
+    # Shortcuts must be fully qualified, i.e., start with "dsbulk." or "datastax-java-driver."
+    shortcuts {
+
+      # DSBulk general shortcuts
+      c = dsbulk.connector.name
+      locale = dsbulk.codec.locale
+      timeZone = dsbulk.codec.timeZone
+      nullStrings = dsbulk.codec.nullStrings
+      dryRun = dsbulk.engine.dryRun
+      maxConcurrentQueries = dsbulk.engine.maxConcurrentQueries
+      maxErrors = dsbulk.log.maxErrors
+      logDir = dsbulk.log.directory
+      verbosity = dsbulk.log.verbosity
+      jmx = dsbulk.monitoring.jmx
+      prometheus = dsbulk.monitoring.prometheus.pull.enabled
+      reportRate = dsbulk.monitoring.reportRate
+      k = dsbulk.schema.keyspace
+      m = dsbulk.schema.mapping
+      query = dsbulk.schema.query
+      t = dsbulk.schema.table
+      g = dsbulk.schema.graph
+      v = dsbulk.schema.vertex
+      e = dsbulk.schema.edge
+      from = dsbulk.schema.from
+      to = dsbulk.schema.to
+      stats = dsbulk.stats.modes
+      partitions = dsbulk.stats.numPartitions
+      timestamp = dsbulk.schema.preserveTimestamp
+      ttl = dsbulk.schema.preserveTtl
+
+      # Driver shortcuts
+      h = datastax-java-driver.basic.contact-points
+      port = datastax-java-driver.basic.default-port
+      dc = datastax-java-driver.basic.load-balancing-policy.local-datacenter
+      b = datastax-java-driver.basic.cloud.secure-connect-bundle
+      cl = datastax-java-driver.basic.request.consistency
+      maxRetries = datastax-java-driver.advanced.retry-policy.max-retries
+      u = datastax-java-driver.advanced.auth-provider.username
+      p = datastax-java-driver.advanced.auth-provider.password
+      allow = datastax-java-driver.basic.load-balancing-policy.evaluator.allow
+      deny = datastax-java-driver.basic.load-balancing-policy.evaluator.deny
+    }
+  }
+}
+
+datastax-java-driver {
+
+  # Basic options.
+  basic {
+    # How often the driver tries to reload the configuration.
+    #
+    # To disable periodic reloading, set this to 0.
+    #
+    # Required: yes (unless you pass a different ConfigLoader to the session builder).
+    # Modifiable at runtime: yes, the new value will be used after the next time the configuration
+    #   gets reloaded.
+    # Overridable in a profile: no
+    config-reload-interval = 5 minutes
+
+    # The driver session name. DSBulk simply calls it "driver". The session name is printed by all driver log messages, between square brackets.
+    session-name = driver
+
+    # The contact points to use for the initial connection to the cluster.
+    #
+    # These are addresses of Cassandra nodes that the driver uses to discover the cluster topology. Only one contact point is required (the driver will retrieve the address of the other nodes automatically), but it is usually a good idea to provide more than one contact point, because if that single contact point is unavailable, the driver cannot initialize itself correctly.
+    #
+    # This must be a list of strings with each contact point specified as "host" or "host:port". If the specified host doesn't have a port, the default port specified in `basic.default-port` will be used. Note that Cassandra 3 and below and DSE 6.7 and below require all nodes in a cluster to share the same port (see CASSANDRA-7544).
+    #
+    # Valid examples of contact points are:
+    # - IPv4 addresses with ports: `[ "192.168.0.1:9042", "192.168.0.2:9042" ]`
+    # - IPv4 addresses without ports: `[ "192.168.0.1", "192.168.0.2" ]`
+    # - IPv6 addresses with ports: `[ "fe80:0:0:0:f861:3eff:fe1d:9d7b:9042", "fe80:0:0:f861:3eff:fe1d:9d7b:9044:9042" ]`
+    # - IPv6 addresses without ports: `[ "fe80:0:0:0:f861:3eff:fe1d:9d7b", "fe80:0:0:f861:3eff:fe1d:9d7b:9044" ]`
+    # - Host names with ports: `[ "host1.com:9042", "host2.com:9042" ]`
+    # - Host names without ports: `[ "host1.com", "host2.com:" ]`
+    #
+    # If the host is a DNS name that resolves to multiple A-records, all the corresponding addresses will be used. Avoid using "localhost" as the host name (since it resolves to both IPv4 and IPv6 addresses on some platforms).
+    #
+    # The heuristic to determine whether or not a contact point is in the form "host" or "host:port" is not 100% accurate for some IPv6 addresses; you should avoid ambiguous IPv6 addresses such as `fe80::f861:3eff:fe1d:1234`, because such a string can be seen either as a combination of IP `fe80::f861:3eff:fe1d` with port 1234, or as IP `fe80::f861:3eff:fe1d:1234` without port. In such cases, DSBulk will not change the contact point. This issue can be avoided by providing IPv6 addresses in full form, e.g. if instead of `fe80::f861:3eff:fe1d:1234` you provide `fe80:0:0:0:0:f861:3eff:fe1d:1234`, then the string is unequivocally parsed as IP `fe80:0:0:0:0:f861:3eff:fe1d` with port 1234.
+    #
+    # Note: on Cloud deployments, DSBulk automatically sets this option to an empty list, as contact points are not allowed to be explicitly provided when connecting to DataStax Astra databases.
+    # @type list<string>
+    contact-points = ["127.0.0.1:9042"]
+
+    # The default port to use for `basic.contact-points`, when a host is specified without port. Note that Cassandra 3 and below and DSE 6.7 and below require all nodes in a cluster to share the same port (see CASSANDRA-7544). If this setting is not specified, the default port will be 9042.
+    default-port = 9042
+
+    # Options for connection to a DataStax Astra database.
+    cloud {
+
+      # The location of the secure bundle used to connect to a Datastax Astra database. This setting must be a path on the local filesystem or a valid URL.
+      #
+      # Examples:
+      #
+      #     "/path/to/bundle.zip"          # path on *Nix systems
+      #     "./path/to/bundle.zip"         # path on *Nix systems, relative to workding directory
+      #     "~/path/to/bundle.zip"         # path on *Nix systems, relative to home directory
+      #     "C:\\path\\to\\bundle.zip"     # path on Windows systems,
+      #                                    # note that you need to escape backslashes in HOCON
+      #     "file:/a/path/to/bundle.zip"   # URL with file protocol
+      #     "http://host.com/bundle.zip"   # URL with HTTP protocol
+      #
+      # Note: if you set this to a non-null value, DSBulk assumes that you are connecting to an DataStax Astra database; in this case, you should not set any of the following settings because they are not compatible with Cloud deployments:
+      #
+      # - `datastax-java-driver.basic.contact-points`
+      # - `datastax-java-driver.basic.request.consistency`
+      # - `datastax-java-driver.advanced.ssl-engine-factory.*`
+      #
+      # If you do so, a log will be emitted and the setting will be ignored.
+      # @type string
+      secure-connect-bundle = null
+
+    }
+
+    request {
+
+      # How long the driver waits for a request to complete. This is a global limit on the duration of a session.execute() call, including any internal retries the driver might do. By default, this value is set very high because DSBulk is optimized for good throughput, rather than good latencies.
+      timeout = 5 minutes
+
+      # The consistency level to use for all queries. Note that stronger consistency levels usually result in reduced throughput. In addition, any level higher than `ONE` will automatically disable continuous paging, which can dramatically reduce read throughput.
+      #
+      # Valid values are: `ANY`, `LOCAL_ONE`, `ONE`, `TWO`, `THREE`, `LOCAL_QUORUM`, `QUORUM`, `EACH_QUORUM`, `ALL`.
+      #
+      # Note: on Cloud deployments, the only accepted consistency level when writing is `LOCAL_QUORUM`. Therefore, the default value is `LOCAL_ONE`, except when loading in Cloud deployments, in which case the default is automatically changed to `LOCAL_QUORUM`.
+      consistency = LOCAL_ONE
+
+      # The serial consistency level. The allowed values are `SERIAL` and `LOCAL_SERIAL`.
+      serial-consistency = LOCAL_SERIAL
+
+      # The default idempotence for all queries executed in DSBulk. Setting this to false will cause all write failures to not be retried.
+      default-idempotence = true
+
+      # The page size. This controls how many rows will be retrieved simultaneously in a single network roundtrip (the goal being to avoid loading too many results in memory at the same time). If there are more results, additional requests will be used to retrieve them (either automatically if you iterate with the sync API, or explicitly with the async API's `fetchNextPage` method). If the value is 0 or negative, it will be ignored and the request will not be paged.
+      page-size = 5000
+
+    }
+
+    # The load balancing policy decides the "query plan" for each query; that is, which nodes to try as coordinators, and in which order.
+    load-balancing-policy {
+
+      # The load balancing policy class to use. If it is not qualified, the driver assumes that it resides in the package `com.datastax.oss.driver.internal.core.loadbalancing`.
+      #
+      # DSBulk uses a special policy that infers the local datacenter from the contact points. You can also specify a custom class that implements `LoadBalancingPolicy` and has a public constructor with two arguments: the `DriverContext` and a `String` representing the profile name.
+      class = com.datastax.oss.driver.internal.core.loadbalancing.DcInferringLoadBalancingPolicy
+
+      # The datacenter that is considered "local": the default load balancing policy will only include nodes from this datacenter in its query plans. Set this to a non-null value if you want to force the local datacenter; otherwise, the `DcInferringLoadBalancingPolicy` used by default by DSBulk will infer the local datacenter from the provided contact points.
+      # @type string
+      local-datacenter = null
+
+      evaluator {
+
+        # An optional custom filter to include/exclude nodes. If present, it must be the fully-qualified name of a class that implements `java.util.function.Predicate<Node>`, and has a public constructor taking two arguments: a `DriverContext` instance and a String representing the current execution profile name.
+        #
+        # The predicate's `test(Node)` method will be invoked each time the policy processes a topology or state change: if it returns false, the node will be set at distance `IGNORED` (meaning the driver won't ever connect to it), and never included in any query plan.
+        #
+        # By default, DSBulk ships with a node filter implementation that honors the following settings:
+        # - `datastax-java-driver.basic.load-balancing-policy.evaluator.allow`: a list of host names or host addresses that should be allowed.
+        # - `datastax-java-driver.basic.load-balancing-policy.evaluator.deny`: a list of host names or host addresses that should be denied.
+        #
+        # See the description of the above settings for more details.
+        # @type string
+        class = com.datastax.oss.dsbulk.workflow.commons.policies.lbp.SimpleNodeDistanceEvaluator
+
+        # An optional list of host names or host addresses that should be allowed to connect. See `datastax-java-driver.basic.contact-points` for a full description of accepted formats.
+        #
+        # This option only has effect when the setting `datastax-java-driver.basic.load-balancing-policy.evaluator.class` refers to DSBulk's default node filter implementation: `com.datastax.oss.dsbulk.workflow.commons.policies.lbp.SimpleNodeDistanceEvaluator`.
+        #
+        # Note: this option is not compatible with DataStax Astra databases.
+        # @type list<string>
+        allow = []
+
+        # An optional list of host names or host addresses that should be denied to connect. See `datastax-java-driver.basic.contact-points` for a full description of accepted formats.
+        #
+        # This option only has effect when the setting `datastax-java-driver.basic.load-balancing-policy.evaluator.class` refers to DSBulk's default node filter implementation: `com.datastax.oss.dsbulk.workflow.commons.policies.lbp.SimpleNodeDistanceEvaluator`.
+        #
+        # Note: this option is not compatible with DataStax Astra databases.
+        # @type list<string>
+        deny = []
+
+      }}
+
+  }
+
+  # Advanced options.
+  advanced {
+    # The maximum number of live sessions that are allowed to coexist in a given VM.
+    #
+    # This is intended to help detect resource leaks in client applications that create too many
+    # sessions and/or do not close them correctly. The driver keeps track of the number of live
+    # sessions in a static variable; if it gets over this threshold, a warning will be logged for
+    # every new session.
+    #
+    # If the value is less than or equal to 0, the feature is disabled: no warning will be issued.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for sessions created after the change.
+    # Overridable in a profile: no
+    session-leak.threshold = 4
+
+    control-connection.timeout = 10 seconds
+
+    connection {
+      # The timeout to use when establishing driver connections.
+      #
+      # This timeout is for controlling how long the driver will wait for the underlying channel
+      # to actually connect to the server. This is not the time limit for completing protocol
+      # negotiations, only the time limit for establishing a channel connection.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      connect-timeout = 5 seconds
+
+      # The timeout to use for internal queries that run as part of the initialization process, just
+      # after we open a connection. If this timeout fires, the initialization of the connection will
+      # fail. If this is the first connection ever, the driver will fail to initialize as well,
+      # otherwise it will retry the connection later.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      init-query-timeout = 5 seconds
+
+      # The timeout to use when the driver changes the keyspace on a connection at runtime (this
+      # happens when the client issues a `USE ...` query, and all connections belonging to the current
+      # session need to be updated).
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      set-keyspace-timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+
+      # The driver maintains a connection pool to each node, according to the distance assigned to it
+      # by the load balancing policy.
+      # If the distance is LOCAL, then local.size connections are opened; if the distance is REMOTE,
+      # then remote.size connections are opened. If the distance is IGNORED, no connections at all
+      # are maintained.
+      pool {
+        # The number of connections in the pool for a node whose distance is LOCAL, that is, a node
+        # that belongs to the local datacenter, as inferred by the load balancing or defined by the
+        # option: datastax-java-driver.basic.load-balancing-policy.local-datacenter.
+        #
+        # Each connection can handle many concurrent requests, so 1 is generally a good place to
+        # start. You should only need higher values in very high performance scenarios, where
+        # connections might start maxing out their I/O thread (see the driver's online manual for
+        # more tuning instructions).
+        #
+        # Required: yes
+        # Modifiable at runtime: yes; when the change is detected, all active pools will be notified
+        #   and will adjust their size.
+        # Overridable in a profile: no
+        local.size = 1
+
+        # The number of connections in the pool for a node whose distance is REMOTE, that is, a node
+        # that does not belong to the local datacenter.
+        #
+        # Note: by default, the built-in load-balancing policies will never assign the REMOTE distance
+        # to any node, to avoid cross-datacenter network traffic. If you want to change this behavior
+        # and understand the consequences, configure your policy to accept nodes in remote
+        # datacenters by adjusting the following advanced options:
+        #
+        # - datastax-java-driver.advanced.load-balancing-policy.dc-failover.max-nodes-per-remote-dc
+        # - datastax-java-driver.advanced.load-balancing-policy.dc-failover.allow-for-local-consistency-levels
+        #
+        # Required: yes
+        # Modifiable at runtime: yes; when the change is detected, all active pools will be notified
+        #   and will adjust their size.
+        # Overridable in a profile: no
+        remote.size = 1
+      }
+
+      # The maximum number of requests that can be executed concurrently on a connection. This must be
+      # strictly positive, and less than 32768.
+      #
+      # We recommend against changing this value: the default of 1024 is fine for most situations,
+      # it's a good balance between sufficient concurrency on the client and reasonable pressure on
+      # the server. If you're looking for a way to limit the global throughput of the session, this is
+      # not the right way to do it: use a request throttler instead (see the `advanced.throttler`
+      # section in this configuration).
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      max-requests-per-connection = 1024
+
+      # The maximum number of "orphaned" requests before a connection gets closed automatically.
+      #
+      # Sometimes the driver writes to a node but stops listening for a response (for example if the
+      # request timed out, or was completed by another node). But we can't safely reuse the stream id
+      # on this connection until we know for sure that the server is done with it. Therefore the id is
+      # marked as "orphaned" until we get a response from the node.
+      #
+      # If the response never comes (or is lost because of a network issue), orphaned ids can
+      # accumulate over time, eventually affecting the connection's throughput. So we monitor them
+      # and close the connection above a given threshold (the pool will replace it).
+      #
+      # The value must be lower than `max-requests-per-connection`.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      max-orphan-requests = 256
+
+      # Whether to log non-fatal errors when the driver tries to open a new connection.
+      #
+      # This error as recoverable, as the driver will try to reconnect according to the reconnection
+      # policy. Therefore some users see them as unnecessary clutter in the logs. On the other hand,
+      # those logs can be handy to debug a misbehaving node.
+      #
+      # Note that some type of errors are always logged, regardless of this option:
+      # - protocol version mismatches (the node gets forced down)
+      # - when the cluster name in system.local doesn't match the other nodes (the node gets forced
+      #   down)
+      # - authentication errors (will be retried)
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      warn-on-init-error = true
+    }
+
+    # Advanced options for the built-in load-balancing policies.
+    load-balancing-policy {
+      # Cross-datacenter failover configuration: configure the load-balancing policies to use nodes
+      # in remote datacenters.
+      dc-failover {
+        # The maximum number of nodes to contact in each remote datacenter.
+        #
+        # By default, this number is zero, to avoid cross-datacenter network traffic. When this
+        # number is greater than zero:
+        #
+        # - The load policies will assign the REMOTE distance to that many nodes in each remote
+        #   datacenter.
+        # - The driver will then attempt to open connections to those nodes. The actual number of
+        #   connections to open to each one of those nodes is configurable via the option:
+        #   datastax-java-driver.advanced.connection.pool.remote.size.
+        # - The load-balancing policies will include those remote nodes (and only those) in query
+        #   plans, effectively enabling cross-datacenter failover.
+        #
+        # Beware that enabling such failover can result in cross-datacenter network traffic spikes,
+        # if the local datacenter is down or experiencing high latencies!
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: yes
+        max-nodes-per-remote-dc = 0
+
+        # Whether cross-datacenter failover should be allowed for requests executed with local
+        # consistency levels (LOCAL_ONE, LOCAL_QUORUM and LOCAL_SERIAL).
+        #
+        # This is disabled by default. Enabling this feature may have unexpected results, since a
+        # local consistency level may have different semantics depending on the replication factor in
+        # use in each datacenter.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: yes
+        allow-for-local-consistency-levels = false
+      }
+    }
+
+    # Whether to schedule reconnection attempts if all contact points are unreachable on the first
+    # initialization attempt.
+    #
+    # If this is true, the driver will retry according to the reconnection policy. The
+    # `SessionBuilder.build()` call -- or the future returned by `SessionBuilder.buildAsync()` --
+    # won't complete until a contact point has been reached.
+    #
+    # If this is false and no contact points are available, the driver will fail with an
+    # AllNodesFailedException.
+    #
+    # Required: yes
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    reconnect-on-init = false
+
+    # The policy that controls how often the driver tries to re-establish connections to down nodes.
+    #
+    # Required: yes
+    # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+    #   and allow child options to be changed at runtime).
+    # Overridable in a profile: no
+    reconnection-policy {
+      # The class of the policy. If it is not qualified, the driver assumes that it resides in the
+      # package com.datastax.oss.driver.internal.core.connection.
+      #
+      # The driver provides two implementations out of the box: ExponentialReconnectionPolicy and
+      # ConstantReconnectionPolicy.
+      #
+      # You can also specify a custom class that implements ReconnectionPolicy and has a public
+      # constructor with a DriverContext argument.
+      class = ExponentialReconnectionPolicy
+
+      # ExponentialReconnectionPolicy starts with the base delay, and doubles it after each failed
+      # reconnection attempt, up to the maximum delay (after that it stays constant).
+      #
+      # ConstantReconnectionPolicy only uses the base-delay value, the interval never changes.
+      base-delay = 1 second
+      max-delay = 60 seconds
+    }
+
+    # The policy that controls if the driver retries requests that have failed on one node.
+    #
+    # Required: yes
+    # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+    #   and allow child options to be changed at runtime).
+    # Overridable in a profile: yes. Note that the driver creates as few instances as possible: if a
+    #   named profile inherits from the default profile, or if two sibling profiles have the exact
+    #   same configuration, they will share a single policy instance at runtime.
+    retry-policy {
+      # The class of the policy. If it is not qualified, the driver assumes that it resides in the
+      # package com.datastax.oss.driver.internal.core.retry.
+      #
+      # The driver provides two implementations out of the box:
+      #
+      # - DefaultRetryPolicy: the default policy, should almost always be the right choice.
+      # - ConsistencyDowngradingRetryPolicy: an alternative policy that weakens consistency guarantees
+      #   as a trade-off to maximize the chance of success when retrying. Use with caution.
+      #
+      # Refer to the manual to understand how these policies work.
+      #
+      # You can also specify a custom class that implements RetryPolicy and has a public constructor
+      # with two arguments: the DriverContext and a String representing the profile name.
+      class = DefaultRetryPolicy
+    }
+
+    # The policy that controls if the driver pre-emptively tries other nodes if a node takes too long
+    # to respond.
+    #
+    # Required: yes
+    # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+    #   and allow child options to be changed at runtime).
+    # Overridable in a profile: yes. Note that the driver creates as few instances as possible: if a
+    #   named profile inherits from the default profile, or if two sibling profiles have the exact
+    #   same configuration, they will share a single policy instance at runtime.
+    speculative-execution-policy {
+      # The class of the policy. If it is not qualified, the driver assumes that it resides in the
+      # package com.datastax.oss.driver.internal.core.specex.
+      #
+      # The following implementations are available out of the box:
+      # - NoSpeculativeExecutionPolicy: never schedule any speculative execution
+      # - ConstantSpeculativeExecutionPolicy: schedule executions based on constant delays. This
+      #   requires the `max-executions` and `delay` options below.
+      #
+      # You can also specify a custom class that implements SpeculativeExecutionPolicy and has a
+      # public constructor with two arguments: the DriverContext and a String representing the
+      # profile name.
+      class = NoSpeculativeExecutionPolicy
+
+      # The maximum number of executions (including the initial, non-speculative execution).
+      # This must be at least one.
+      // max-executions = 3
+
+      # The delay between each execution. 0 is allowed, and will result in all executions being sent
+      # simultaneously when the request starts.
+      #
+      # Note that sub-millisecond precision is not supported, any excess precision information will be
+      # dropped; in particular, delays of less than 1 millisecond are equivalent to 0.
+      #
+      # Also note that, because speculative executions are scheduled on the driver's timer thread,
+      # the duration specified here must be greater than the timer tick duration defined by the
+      # advanced.netty.timer.tick-duration setting (see below). If that is not the case, speculative
+      # executions will not be triggered as timely as desired.
+      #
+      # This must be positive or 0.
+      // delay = 100 milliseconds
+    }
+
+    # The component that handles authentication on each new connection.
+    #
+    # Required: no. If the 'class' child option is absent, no authentication will occur.
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    #
+    # Note that the contents of this section can be overridden programmatically with
+    # SessionBuilder.withAuthProvider or SessionBuilder.withAuthCredentials.
+    auth-provider {
+      # The class of the provider. If it is not qualified, the driver assumes that it resides in one
+      # of the following packages:
+      # - com.datastax.oss.driver.internal.core.auth
+      # - com.datastax.dse.driver.internal.core.auth
+      #
+      # The driver provides two implementations:
+      # - PlainTextAuthProvider: uses plain-text credentials. It requires the `username` and
+      #   `password` options below. When connecting to Datastax Enterprise, an optional
+      #   `authorization-id` can also be specified.
+      #   For backward compatibility with previous driver versions, you can also use the class name
+      #   "DsePlainTextAuthProvider" for this provider.
+      # - DseGssApiAuthProvider: provides GSSAPI authentication for DSE clusters secured with
+      #   DseAuthenticator. See the example below and refer to the manual for detailed instructions.
+      #
+      # You can also specify a custom class that implements AuthProvider and has a public constructor
+      # with a DriverContext argument (to simplify this, the driver provides two abstract classes that
+      # can be extended: PlainTextAuthProviderBase and DseGssApiAuthProviderBase).
+      #
+      # Finally, you can configure a provider instance programmatically with
+      # DseSessionBuilder#withAuthProvider. In that case, it will take precedence over the
+      # configuration.
+      // class = PlainTextAuthProvider
+      #
+      # Sample configuration for plain-text authentication providers:
+      // username = cassandra
+      // password = cassandra
+      #
+      # Proxy authentication: allows to login as another user or role (valid for both
+      # PlainTextAuthProvider and DseGssApiAuthProvider):
+      // authorization-id = userOrRole
+      #
+      # The settings below are only applicable to DseGssApiAuthProvider:
+      #
+      # Service name. For example, if in your dse.yaml configuration file the
+      # "kerberos_options/service_principal" setting is "cassandra/my.host.com@MY.REALM.COM", then set
+      # this option to "cassandra". If this value is not explicitly set via configuration (in an
+      # application.conf or programmatically), the driver will attempt to set it via a System
+      # property. The property should be "dse.sasl.service". For backwards compatibility with 1.x
+      # versions of the driver, if "dse.sasl.service" is not set as a System property, the driver will
+      # attempt to use "dse.sasl.protocol" as a fallback (which is the property for the 1.x driver).
+      //service = "cassandra"
+      #
+      # Login configuration. It is also possible to provide login configuration through a standard
+      # JAAS configuration file. The below configuration is just an example, see all possible options
+      # here:
+      # https://docs.oracle.com/javase/6/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/Krb5LoginModule.html
+      // login-configuration {
+      //   principal = "cassandra@DATASTAX.COM"
+      //   useKeyTab = "true"
+      //   refreshKrb5Config = "true"
+      //   keyTab = "/path/to/keytab/file"
+      // }
+      #
+      # Internal SASL properties, if any, such as QOP.
+      // sasl-properties {
+      //   javax.security.sasl.qop = "auth-conf"
+      // }
+    }
+
+    # The SSL engine factory that will initialize an SSL engine for each new connection to a server.
+    #
+    # Required: no. If the 'class' child option is absent, SSL won't be activated.
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    #
+    # Note that the contents of this section can be overridden programmatically with
+    # SessionBuilder.withSslEngineFactory or SessionBuilder#withSslContext.
+    ssl-engine-factory {
+      # The class of the factory. If it is not qualified, the driver assumes that it resides in the
+      # package com.datastax.oss.driver.internal.core.ssl.
+      #
+      # The driver provides a single implementation out of the box: DefaultSslEngineFactory, that uses
+      # the JDK's built-in SSL implementation.
+      #
+      # You can also specify a custom class that implements SslEngineFactory and has a public
+      # constructor with a DriverContext argument.
+      // class = DefaultSslEngineFactory
+
+      # Sample configuration for the default SSL factory:
+      # The cipher suites to enable when creating an SSLEngine for a connection.
+      # This property is optional. If it is not present, the driver won't explicitly enable cipher
+      # suites on the engine, which according to the JDK documentations results in "a minimum quality
+      # of service".
+      // cipher-suites = [ "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA" ]
+
+      # Whether or not to require validation that the hostname of the server certificate's common
+      # name matches the hostname of the server being connected to. If not set, defaults to true.
+      // hostname-validation = true
+
+      # The locations and passwords used to access truststore and keystore contents.
+      # These properties are optional. If either truststore-path or keystore-path are specified,
+      # the driver builds an SSLContext from these files.  If neither option is specified, the
+      # default SSLContext is used, which is based on system property configuration.
+      // truststore-path = /path/to/client.truststore
+      // truststore-password = password123
+      // keystore-path = /path/to/client.keystore
+      // keystore-password = password123
+    }
+
+    # The generator that assigns a microsecond timestamp to each request.
+    #
+    # Required: yes
+    # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+    #   and allow child options to be changed at runtime).
+    # Overridable in a profile: yes. Note that the driver creates as few instances as possible: if a
+    #   named profile inherits from the default profile, or if two sibling profiles have the exact
+    #   same configuration, they will share a single generator instance at runtime.
+    timestamp-generator {
+      # The class of the generator. If it is not qualified, the driver assumes that it resides in the
+      # package com.datastax.oss.driver.internal.core.time.
+      #
+      # The driver provides the following implementations out of the box:
+      # - AtomicTimestampGenerator: timestamps are guaranteed to be unique across all client threads.
+      # - ThreadLocalTimestampGenerator: timestamps that are guaranteed to be unique within each
+      #   thread only.
+      # - ServerSideTimestampGenerator: do not generate timestamps, let the server assign them.
+      #
+      # You can also specify a custom class that implements TimestampGenerator and has a public
+      # constructor with two arguments: the DriverContext and a String representing the profile name.
+      class = AtomicTimestampGenerator
+
+      # To guarantee that queries are applied on the server in the same order as the client issued
+      # them, timestamps must be strictly increasing. But this means that, if the driver sends more
+      # than one query per microsecond, timestamps will drift in the future. While this could happen
+      # occasionally under high load, it should not be a regular occurrence. Therefore the built-in
+      # implementations log a warning to detect potential issues.
+      drift-warning {
+        # How far in the future timestamps are allowed to drift before the warning is logged.
+        # If it is undefined or set to 0, warnings are disabled.
+        threshold = 1 second
+
+        # How often the warning will be logged if timestamps keep drifting above the threshold.
+        interval = 10 seconds
+      }
+
+      # Whether to force the driver to use Java's millisecond-precision system clock.
+      # If this is false, the driver will try to access the microsecond-precision OS clock via native
+      # calls (and fallback to the Java one if the native calls fail).
+      # Unless you explicitly want to avoid native calls, there's no reason to change this.
+      force-java-clock = false
+    }
+
+    # Request trackers are session-wide components that get notified of the outcome of requests.
+    request-tracker {
+      # The list of trackers to register.
+      #
+      # This must be a list of class names, either fully-qualified or non-qualified; if the latter,
+      # the driver assumes that the class resides in the package
+      # com.datastax.oss.driver.internal.core.tracker.
+      #
+      # All classes specified here must implement
+      # com.datastax.oss.driver.api.core.tracker.RequestTracker and have a public constructor with a
+      # DriverContext argument.
+      #
+      # The driver provides the following implementation out of the box:
+      # - RequestLogger: logs requests (see the parameters below).
+      #
+      # You can also pass instances of your trackers programmatically with
+      # CqlSession.builder().addRequestTracker().
+      #
+      # Required: no
+      # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+      #   and allow child options to be changed at runtime).
+      # Overridable in a profile: no
+      #classes = [RequestLogger,com.example.app.MyTracker]
+
+      # Parameters for RequestLogger. All of them can be overridden in a profile, and changed at
+      # runtime (the new values will be taken into account for requests logged after the change).
+      logs {
+        # Whether to log successful requests.
+        // success.enabled = true
+
+        slow {
+          # The threshold to classify a successful request as "slow". If this is unset, all successful
+          # requests will be considered as normal.
+          // threshold = 1 second
+
+          # Whether to log slow requests.
+          // enabled = true
+        }
+
+        # Whether to log failed requests.
+        // error.enabled = true
+
+        # The maximum length of the query string in the log message. If it is longer than that, it
+        # will be truncated.
+        // max-query-length = 500
+
+        # Whether to log bound values in addition to the query string.
+        // show-values = true
+
+        # The maximum length for bound values in the log message. If the formatted representation of a
+        # value is longer than that, it will be truncated.
+        // max-value-length = 50
+
+        # The maximum number of bound values to log. If a request has more values, the list of values
+        # will be truncated.
+        // max-values = 50
+
+        # Whether to log stack traces for failed queries. If this is disabled, the log will just
+        # include the exception's string representation (generally the class name and message).
+        // show-stack-traces = true
+      }
+    }
+
+    # A session-wide component that controls the rate at which requests are executed.
+    #
+    # Implementations vary, but throttlers generally track a metric that represents the level of
+    # utilization of the session, and prevent new requests from starting when that metric exceeds a
+    # threshold. Pending requests may be enqueued and retried later.
+    #
+    # From the public API's point of view, this process is mostly transparent: any time that the
+    # request is throttled is included in the session.execute() or session.executeAsync() call.
+    # Similarly, the request timeout encompasses throttling: the timeout starts ticking before the
+    # throttler has started processing the request; a request may time out while it is still in the
+    # throttler's queue, before the driver has even tried to send it to a node.
+    #
+    # The only visible effect is that a request may fail with a RequestThrottlingException, if the
+    # throttler has determined that it can neither allow the request to proceed now, nor enqueue it;
+    # this indicates that your session is overloaded.
+    #
+    # Required: yes
+    # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+    #   and allow child options to be changed at runtime).
+    # Overridable in a profile: no
+    throttler {
+      # The class of the throttler. If it is not qualified, the driver assumes that it resides in
+      # the package com.datastax.oss.driver.internal.core.session.throttling.
+      #
+      # The driver provides the following implementations out of the box:
+      #
+      # - PassThroughRequestThrottler: does not perform any kind of throttling, all requests are
+      #   allowed to proceed immediately. Required options: none.
+      #
+      # - ConcurrencyLimitingRequestThrottler: limits the number of requests that can be executed in
+      #   parallel. Required options: max-concurrent-requests, max-queue-size.
+      #
+      # - RateLimitingRequestThrottler: limits the request rate per second. Required options:
+      #   max-requests-per-second, max-queue-size, drain-interval.
+      #
+      # You can also specify a custom class that implements RequestThrottler and has a public
+      # constructor with a DriverContext argument.
+      class = PassThroughRequestThrottler
+
+      # The maximum number of requests that can be enqueued when the throttling threshold is exceeded.
+      # Beyond that size, requests will fail with a RequestThrottlingException.
+      // max-queue-size = 10000
+
+      # The maximum number of requests that are allowed to execute in parallel.
+      # Only used by ConcurrencyLimitingRequestThrottler.
+      // max-concurrent-requests = 10000
+
+      # The maximum allowed request rate.
+      # Only used by RateLimitingRequestThrottler.
+      // max-requests-per-second = 10000
+
+      # How often the throttler attempts to dequeue requests. This is the only way for rate-based
+      # throttling, because the completion of an active request does not necessarily free a "slot" for
+      # a queued one (the rate might still be too high).
+      #
+      # You want to set this high enough that each attempt will process multiple entries in the queue,
+      # but not delay requests too much. A few milliseconds is probably a happy medium.
+      #
+      # Only used by RateLimitingRequestThrottler.
+      // drain-interval = 10 milliseconds
+    }
+
+    # The list of node state listeners to register. Node state listeners are session-wide
+    # components that listen for node state changes (e.g., when nodes go down or back up).
+    #
+    # This must be a list of fully-qualified class names; classes specified here must implement
+    # com.datastax.oss.driver.api.core.metadata.NodeStateListener and have a public
+    # constructor with a DriverContext argument.
+    #
+    # You can also pass instances of your listeners programmatically with
+    # CqlSession.builder().addNodeStateListener().
+    #
+    # Required: no
+    # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+    #   and allow child options to be changed at runtime).
+    # Overridable in a profile: no
+    #advanced.node-state-listener.classes = [com.example.app.MyListener1,com.example.app.MyListener2]
+
+    # The list of schema change listeners to register. Schema change listeners are session-wide
+    # components that listen for schema changes (e.g., when tables are created or dropped).
+    #
+    # This must be a list of fully-qualified class names; classes specified here must implement
+    # com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener and have a public
+    # constructor with a DriverContext argument.
+    #
+    # You can also pass instances of your listeners programmatically with
+    # CqlSession.builder().addSchemaChangeListener().
+    #
+    # Required: no
+    # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+    #   and allow child options to be changed at runtime).
+    # Overridable in a profile: no
+    #advanced.schema-change-listener.classes = [com.example.app.MyListener1,com.example.app.MyListener2]
+
+    # The address translator to use to convert the addresses sent by Cassandra nodes into ones that
+    # the driver uses to connect.
+    # This is only needed if the nodes are not directly reachable from the driver (for example, the
+    # driver is in a different network region and needs to use a public IP, or it connects through a
+    # proxy).
+    #
+    # Required: yes
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    address-translator {
+      # The class of the translator. If it is not qualified, the driver assumes that it resides in
+      # the package com.datastax.oss.driver.internal.core.addresstranslation.
+      #
+      # The driver provides the following implementations out of the box:
+      # - PassThroughAddressTranslator: returns all addresses unchanged
+      # - Ec2MultiRegionAddressTranslator: suitable for an Amazon multi-region EC2 deployment where
+      #   clients are also deployed in EC2. It optimizes network costs by favoring private IPs over
+      #   public ones whenever possible.
+      #
+      # You can also specify a custom class that implements AddressTranslator and has a public
+      # constructor with a DriverContext argument.
+      class = PassThroughAddressTranslator
+    }
+
+    # Whether to resolve the addresses passed to `basic.contact-points`.
+    #
+    # If this is true, addresses are created with `InetSocketAddress(String, int)`: the host name will
+    # be resolved the first time, and the driver will use the resolved IP address for all subsequent
+    # connection attempts.
+    #
+    # If this is false, addresses are created with `InetSocketAddress.createUnresolved()`: the host
+    # name will be resolved again every time the driver opens a new connection. This is useful for
+    # containerized environments where DNS records are more likely to change over time (note that the
+    # JVM and OS have their own DNS caching mechanisms, so you might need additional configuration
+    # beyond the driver).
+    #
+    # This option only applies to the contact points specified in the configuration. It has no effect
+    # on:
+    # - programmatic contact points passed to SessionBuilder.addContactPoints: these addresses are
+    #   built outside of the driver, so it is your responsibility to provide unresolved instances.
+    # - dynamically discovered peers: the driver relies on Cassandra system tables, which expose raw
+    #   IP addresses. Use a custom address translator to convert them to unresolved addresses (if
+    #   you're in a containerized environment, you probably already need address translation anyway).
+    #
+    # Required: no (defaults to true)
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    resolve-contact-points = true
+
+    protocol {
+      # The native protocol version to use.
+      #
+      # If this option is absent, the driver looks up the versions of the nodes at startup (by default
+      # in system.peers.release_version), and chooses the highest common protocol version.
+      # For example, if you have a mixed cluster with Apache Cassandra 2.1 nodes (protocol v3) and
+      # Apache Cassandra 3.0 nodes (protocol v3 and v4), then protocol v3 is chosen. If the nodes
+      # don't have a common protocol version, initialization fails.
+      #
+      # If this option is set, then the given version will be used for all connections, without any
+      # negotiation or downgrading. If any of the contact points doesn't support it, that contact
+      # point will be skipped.
+      #
+      # Once the protocol version is set, it can't change for the rest of the driver's lifetime; if
+      # an incompatible node joins the cluster later, connection will fail and the driver will force
+      # it down (i.e. never try to connect to it again).
+      #
+      # You can check the actual version at runtime with Cluster.getContext().getProtocolVersion().
+      #
+      # Required: no
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      // version = V4
+
+      # The name of the algorithm used to compress protocol frames.
+      #
+      # The possible values are:
+      # - lz4: requires net.jpountz.lz4:lz4 in the classpath.
+      # - snappy: requires org.xerial.snappy:snappy-java in the classpath.
+      # - the string "none" to indicate no compression (this is functionally equivalent to omitting
+      #   the option).
+      #
+      # The driver depends on the compression libraries, but they are optional. Make sure you
+      # redeclare an explicit dependency in your project. Refer to the driver's POM or manual for the
+      # exact version.
+      #
+      # Required: no. If the option is absent, protocol frames are not compressed.
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      // compression = lz4
+
+      # The maximum length of the frames supported by the driver. Beyond that limit, requests will
+      # fail with an exception
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      max-frame-length = 256 MiB
+    }
+
+    request {
+      # Whether a warning is logged when a request (such as a CQL `USE ...`) changes the active
+      # keyspace.
+      # Switching keyspace at runtime is highly discouraged, because it is inherently unsafe (other
+      # requests expecting the old keyspace might be running concurrently), and may cause statements
+      # prepared before the change to fail.
+      # It should only be done in very specific use cases where there is only a single client thread
+      # executing synchronous queries (such as a cqlsh-like interpreter). In other cases, clients
+      # should prefix table names in their queries instead.
+      #
+      # Note that CASSANDRA-10145 (scheduled for C* 4.0) will introduce a per-request keyspace option
+      # as a workaround to this issue.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for keyspace switches occurring after
+      #   the change.
+      # Overridable in a profile: no
+      warn-if-set-keyspace = true
+
+      # If tracing is enabled for a query, this controls how the trace is fetched.
+      trace {
+        # How many times the driver will attempt to fetch the query if it is not ready yet.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for traces fetched after the change.
+        # Overridable in a profile: yes
+        attempts = 5
+
+        # The interval between each attempt.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for traces fetched after the change.
+        # Overridable in a profile: yes
+        interval = 3 milliseconds
+
+        # The consistency level to use for trace queries.
+        # Note that the default replication strategy for the system_traces keyspace is SimpleStrategy
+        # with RF=2, therefore LOCAL_ONE might not work if the local DC has no replicas for a given
+        # trace id.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for traces fetched after the change.
+        # Overridable in a profile: yes
+        consistency = ONE
+      }
+
+      # Whether logging of server warnings generated during query execution should be disabled by the
+      # driver. All server generated warnings will be available programmatically via the ExecutionInfo
+      # object on the executed statement's ResultSet. If set to "false", this will prevent the driver
+      # from logging these warnings.
+      #
+      # NOTE: The log formatting for these warning messages will reuse the options defined for
+      # advanced.request-tracker.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for query warnings received after the change.
+      # Overridable in a profile: yes
+      log-warnings = true
+    }
+
+    # Graph (DataStax Enterprise only)
+    graph {
+      # The sub-protocol the driver will use to communicate with DSE Graph, on top of the Cassandra
+      # native protocol.
+      #
+      # You should almost never have to change this: the driver sets it automatically, based on the
+      # information it has about the server. One exception is if you use the script API against a
+      # legacy DSE version (5.0.3 or older). In that case, you need to force the sub-protocol to
+      # "graphson-1.0".
+      #
+      # This can also be overridden programmatically with GraphStatement.setSubProtocol(). If both are
+      # specified, the programmatic value takes precedence, and this option is ignored.
+      #
+      # Possible values with built-in support in the driver are:
+      # [ "graphson-1.0", "graphson-2.0", "graph-binary-1.0"]
+      #
+      # IMPORTANT: The default value for the Graph sub-protocol is based only on the DSE
+      # version. If the version is DSE 6.7 and lower, "graphson-2.0" will be the default. For DSE 6.8
+      # and higher, the default value is "graphson-binary-1.0".
+      #
+      # Required: no
+      # Modifiable at runtime: yes, the new value will be used for requests issued after the change.
+      # Overridable in a profile: yes
+      // sub-protocol = "graphson-2.0"
+
+      #
+      # Whether or not Graph paging should be enabled or disabled for all queries.
+      #
+      # <p>If AUTO is set, the driver will decide whether or not to enable Graph paging
+      # based on the protocol version in use and the DSE version of all hosts. For this reason it is
+      # usually not necessary to change this setting.
+      #
+      # <p><b>IMPORTANT</b>: Paging for DSE Graph is only available in DSE 6.8 and higher, and
+      # requires protocol version DSE_V1 or higher and graphs created with the Native engine; enabling
+      # paging for clusters and graphs that do not meet this requirement may result in query failures.
+      #
+      # Supported values are: ENABLED, DISABLED, AUTO
+      paging-enabled = "AUTO"
+
+
+      paging-options {
+
+        # The page size.
+        #
+        # The value specified here can be interpreted in number of rows.
+        # Interpetation in number of bytes is not supported for graph continuous paging queries.
+        #
+        # It controls how many rows will be retrieved simultaneously in a single
+        # network roundtrip (the goal being to avoid loading too many results in memory at the same
+        # time). If there are more results, additional requests will be used to retrieve them (either
+        # automatically if you iterate with the sync API, or explicitly with the async API's
+        # fetchNextPage method).
+        #
+        # The default is the same as the driver's normal request page size,
+        # i.e., 5000 (rows).
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+        #   the change
+        # Overridable in a profile: yes
+        page-size = ${datastax-java-driver.advanced.continuous-paging.page-size}
+
+        # The maximum number of pages to return.
+        #
+        # The default is zero, which means retrieve all pages.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+        #   the change
+        # Overridable in a profile: yes
+        max-pages = ${datastax-java-driver.advanced.continuous-paging.max-pages}
+
+        # Returns the maximum number of pages per second.
+        #
+        # The default is zero, which means no limit.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+        #   the change
+        # Overridable in a profile: yes
+        max-pages-per-second = ${datastax-java-driver.advanced.continuous-paging.max-pages-per-second}
+
+        # Returns the maximum number of pages per second.
+        #
+        # The default is zero, which means no limit.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+        #   the change
+        # Overridable in a profile: yes
+        max-enqueued-pages = ${datastax-java-driver.advanced.continuous-paging.max-enqueued-pages}
+      }
+    }
+
+    # Continuous paging (DataStax Enterprise only)
+    continuous-paging {
+      # The page size.
+      #
+      # The value specified here can be interpreted in number of rows
+      # or in number of bytes, depending on the unit defined with page-unit (see below).
+      #
+      # It controls how many rows (or how much data) will be retrieved simultaneously in a single
+      # network roundtrip (the goal being to avoid loading too many results in memory at the same
+      # time). If there are more results, additional requests will be used to retrieve them (either
+      # automatically if you iterate with the sync API, or explicitly with the async API's
+      # fetchNextPage method).
+      #
+      # The default is the same as the driver's normal request page size,
+      # i.e., 5000 (rows).
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+      #   the change
+      # Overridable in a profile: yes
+      page-size = ${datastax-java-driver.basic.request.page-size}
+
+      # Whether the page-size option should be interpreted in number of rows or bytes.
+      #
+      # The default is false, i.e., the page size will be interpreted in number of rows.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+      #   the change
+      # Overridable in a profile: yes
+      page-size-in-bytes = false
+
+      # The maximum number of pages to return.
+      #
+      # The default is zero, which means retrieve all pages.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+      #   the change
+      # Overridable in a profile: yes
+      max-pages = 0
+
+      # Returns the maximum number of pages per second.
+      #
+      # The default is zero, which means no limit.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+      #   the change
+      # Overridable in a profile: yes
+      max-pages-per-second = 0
+
+      # The maximum number of pages that can be stored in the local queue.
+      #
+      # This value must be positive. The default is 4.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+      #   the change
+      # Overridable in a profile: yes
+      max-enqueued-pages = 4
+
+      # Timeouts for continuous paging.
+      #
+      # Note that there is no global timeout for continuous paging as there is
+      # for regular queries, because continuous paging queries can take an arbitrarily
+      # long time to complete.
+      #
+      # Instead, timeouts are applied to each exchange between the driver and the coordinator. In
+      # other words, if the driver decides to retry, all timeouts are reset.
+      timeout {
+
+        # How long to wait for the coordinator to send the first page.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+        #   the change
+        # Overridable in a profile: yes
+        first-page = 2 seconds
+
+        # How long to wait for the coordinator to send subsequent pages.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for continuous requests issued after
+        #   the change
+        # Overridable in a profile: yes
+        other-pages = 1 second
+
+      }
+    }
+
+    # DataStax Insights
+    monitor-reporting {
+      # Whether to send monitoring events.
+      #
+      # The default is true.
+      #
+      # Required: no (defaults to true)
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      enabled = true
+    }
+
+    metrics {
+      # Metrics Factory configuration.
+      factory {
+        # The class for the metrics factory.
+        #
+        # The driver provides out-of-the-box support for three metrics libraries: Dropwizard,
+        # Micrometer and MicroProfile Metrics.
+        #
+        # Dropwizard is the default metrics library in the driver; to use Dropwizard, this value
+        # should be left to its default, "DefaultMetricsFactory", or set to
+        # "DropwizardMetricsFactory". The only difference between the two is that the former will work
+        # even if Dropwizard is not present on the classpath (in which case it will silently disable
+        # metrics), while the latter requires its presence.
+        #
+        # To select Micrometer, set the value to "MicrometerMetricsFactory", and to select
+        # MicroProfile Metrics, set the value to "MicroProfileMetricsFactory". For these libraries to
+        # be used, you will also need to add an additional dependency:
+        # - Micrometer: com.datastax.oss:java-driver-metrics-micrometer
+        # - MicroProfile: com.datastax.oss:java-driver-metrics-microprofile
+        #
+        # If you would like to use another metrics library, set this value to the fully-qualified name
+        # of a class that implements com.datastax.oss.driver.internal.core.metrics.MetricsFactory.
+        #
+        # It is also possible to use "NoopMetricsFactory", which forcibly disables metrics completely.
+        # In fact, "DefaultMetricsFactory" delegates to "DropwizardMetricsFactory" if Dropwizard is
+        # present on the classpath, or to "NoopMetricsFactory" if it isn't.
+        #
+        # Note: specifying a metrics factory is not enough to enable metrics; for the driver to
+        # actually start collecting metrics, you also need to specify which metrics to collect. See
+        # the following options for more information:
+        # - advanced.metrics.session.enabled
+        # - advanced.metrics.node.enabled
+        #
+        # See also the driver online manual for extensive instructions about how to configure metrics.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        class = DefaultMetricsFactory
+      }
+
+      # This section configures how metric ids are generated. A metric id is a unique combination of
+      # a metric name and metric tags.
+      id-generator {
+
+        # The class name of a component implementing
+        # com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator. If it is not qualified, the
+        # driver assumes that it resides in the package com.datastax.oss.driver.internal.core.metrics.
+        #
+        # The driver ships with two built-in implementations:
+        #
+        # - DefaultMetricIdGenerator: generates identifiers composed solely of (unique) metric names;
+        #   it does not generate tags. It is mostly suitable for use with metrics libraries that do
+        #   not support tags, like Dropwizard.
+        # - TaggingMetricIdGenerator: generates identifiers composed of name and tags. It is mostly
+        #   suitable for use with metrics libraries that support tags, like Micrometer or MicroProfile
+        #   Metrics.
+        #
+        # For example, here is how each one of them generates identifiers for the session metric
+        # "bytes-sent", assuming that the session is named "s0":
+        # - DefaultMetricIdGenerator: name "s0.bytes-sent", tags: {}.
+        # - TaggingMetricIdGenerator: name "session.bytes-sent", tags: {"session":"s0"}
+        #
+        # Here is how each one of them generates identifiers for the node metric "bytes-sent",
+        # assuming that the session is named "s0", and the node's broadcast address is 10.1.2.3:9042:
+        # - DefaultMetricIdGenerator: name "s0.nodes.10_1_2_3:9042.bytes-sent", tags: {}.
+        # - TaggingMetricIdGenerator: name "nodes.bytes-sent", tags: { "session" : "s0",
+        #   "node" : "\10.1.2.3:9042" }
+        #
+        # As shown above, both built-in implementations generate names that are path-like structures
+        # separated by dots. This is indeed the most common expected format by reporting tools.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        class = DefaultMetricIdGenerator
+
+        # An optional prefix to prepend to each generated metric name.
+        #
+        # The prefix should not start nor end with a dot or any other path separator; the following
+        # are two valid examples: "cassandra" or "myapp.prod.cassandra".
+        #
+        # For example, if this prefix is set to "cassandra", here is how the session metric
+        # "bytes-sent" would be named, assuming that the session is named "s0":
+        # - with DefaultMetricIdGenerator: "cassandra.s0.bytes-sent"
+        # - with TaggingMetricIdGenerator: "cassandra.session.bytes-sent"
+        #
+        # Here is how the node metric "bytes-sent" would be named, assuming that the session is named
+        # "s0", and the node's broadcast address is 10.1.2.3:9042:
+        # - with DefaultMetricIdGenerator: "cassandra.s0.nodes.10_1_2_3:9042.bytes-sent"
+        # - with TaggingMetricIdGenerator: "cassandra.nodes.bytes-sent"
+        #
+        # Required: no
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        // prefix = "cassandra"
+      }
+
+      # The session-level metrics (all disabled by default).
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      session {
+        enabled = [
+          # The number and rate of bytes sent for the entire session (exposed as a Meter if available,
+          # otherwise as a Counter).
+          // bytes-sent,
+
+          # The number and rate of bytes received for the entire session (exposed as a Meter if
+          # available, otherwise as a Counter).
+          // bytes-received
+
+          # The number of nodes to which the driver has at least one active connection (exposed as a
+          # Gauge<Integer>).
+          // connected-nodes,
+
+          # The throughput and latency percentiles of CQL requests (exposed as a Timer).
+          #
+          # This corresponds to the overall duration of the session.execute() call, including any
+          # retry.
+          // cql-requests,
+
+          # The number of CQL requests that timed out -- that is, the session.execute() call failed
+          # with a DriverTimeoutException (exposed as a Counter).
+          // cql-client-timeouts,
+
+          # The size of the driver-side cache of CQL prepared statements (exposed as a Gauge<Long>).
+          #
+          # The cache uses weak values eviction, so this represents the number of PreparedStatement
+          # instances that your application has created, and is still holding a reference to. Note
+          # that the returned value is approximate.
+          // cql-prepared-cache-size,
+
+          # How long requests are being throttled (exposed as a Timer).
+          #
+          # This is the time between the start of the session.execute() call, and the moment when
+          # the throttler allows the request to proceed.
+          // throttling.delay,
+
+          # The size of the throttling queue (exposed as a Gauge<Integer>).
+          #
+          # This is the number of requests that the throttler is currently delaying in order to
+          # preserve its SLA. This metric only works with the built-in concurrency- and rate-based
+          # throttlers; in other cases, it will always be 0.
+          // throttling.queue-size,
+
+          # The number of times a request was rejected with a RequestThrottlingException (exposed as
+          # a Counter)
+          // throttling.errors,
+
+          # The throughput and latency percentiles of DSE continuous CQL requests (exposed as a
+          # Timer).
+          #
+          # This metric is a session-level metric and corresponds to the overall duration of the
+          # session.executeContinuously() call, including any retry.
+          #
+          # Note that this metric is analogous to the OSS driver's 'cql-requests' metrics, but for
+          # continuous paging requests only. Continuous paging requests do not update the
+          # 'cql-requests' metric, because they are usually much longer. Only the following metrics
+          # are updated during a continuous paging request:
+          #
+          # - At node level: all the usual metrics available for normal CQL requests, such as
+          #   'cql-messages' and error-related metrics (but these are only updated for the first
+          #   page of results);
+          # - At session level: only 'continuous-cql-requests' is updated (this metric).
+          // continuous-cql-requests,
+
+          # The throughput and latency percentiles of Graph requests (exposed as a Timer).
+          #
+          # This metric is a session-level metric and corresponds to the overall duration of the
+          # session.execute(GraphStatement) call, including any retry.
+          // graph-requests,
+
+          # The number of graph requests that timed out -- that is, the
+          # session.execute(GraphStatement) call failed with a DriverTimeoutException (exposed as a
+          # Counter).
+          #
+          # Note that this metric is analogous to the OSS driver's 'cql-client-timeouts' metrics, but
+          # for Graph requests only.
+          // graph-client-timeouts
+
+        ]
+
+        # Extra configuration (for the metrics that need it)
+
+        # Required: if the 'cql-requests' metric is enabled, and Dropwizard or Micrometer is used.
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        cql-requests {
+
+          # The largest latency that we expect to record.
+          #
+          # This should be slightly higher than request.timeout (in theory, readings can't be higher
+          # than the timeout, but there might be a small overhead due to internal scheduling).
+          #
+          # This is used to scale internal data structures. If a higher recording is encountered at
+          # runtime, it is discarded and a warning is logged.
+          # Valid for: Dropwizard, Micrometer.
+          highest-latency = 3 seconds
+
+          # The shortest latency that we expect to record. This is used to scale internal data
+          # structures.
+          # Valid for: Micrometer.
+          lowest-latency = 1 millisecond
+
+          # The number of significant decimal digits to which internal structures will maintain
+          # value resolution and separation (for example, 3 means that recordings up to 1 second
+          # will be recorded with a resolution of 1 millisecond or better).
+          #
+          # For Dropwizard, this must be between 0 and 5. If the value is out of range, it defaults to
+          # 3 and a warning is logged.
+          # Valid for: Dropwizard, Micrometer.
+          significant-digits = 3
+
+          # The interval at which percentile data is refreshed.
+          #
+          # The driver records latency data in a "live" histogram, and serves results from a cached
+          # snapshot. Each time the snapshot gets older than the interval, the two are switched.
+          # Note that this switch happens upon fetching the metrics, so if you never fetch the
+          # recording interval might grow higher (that shouldn't be an issue in a production
+          # environment because you would typically have a metrics reporter that exports to a
+          # monitoring tool at a regular interval).
+          #
+          # In practice, this means that if you set this to 5 minutes, you're looking at data from a
+          # 5-minute interval in the past, that is at most 5 minutes old. If you fetch the metrics
+          # at a faster pace, you will observe the same data for 5 minutes until the interval
+          # expires.
+          #
+          # Note that this does not apply to the total count and rates (those are updated in real
+          # time).
+          # Valid for: Dropwizard.
+          refresh-interval = 5 minutes
+
+          # An optional list of latencies to track as part of the application's service-level
+          # objectives (SLOs).
+          #
+          # If defined, the histogram is guaranteed to contain these boundaries alongside other
+          # buckets used to generate aggregable percentile approximations.
+          # Valid for: Micrometer.
+          // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
+
+        }
+
+        # Required: if the 'throttling.delay' metric is enabled, and Dropwizard or Micrometer is used.
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        throttling.delay {
+          highest-latency = 3 seconds
+          lowest-latency = 1 millisecond
+          significant-digits = 3
+          refresh-interval = 5 minutes
+          // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
+        }
+
+        # Required: if the 'continuous-cql-requests' metric is enabled, and Dropwizard or Micrometer
+        # is used.
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        continuous-cql-requests {
+          highest-latency = 120 seconds
+          lowest-latency = 10 milliseconds
+          significant-digits = 3
+          refresh-interval = 5 minutes
+          // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
+        }
+
+        # Required: if the 'graph-requests' metric is enabled, and Dropwizard or Micrometer is used.
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        graph-requests {
+          highest-latency = 12 seconds
+          lowest-latency = 1 millisecond
+          significant-digits = 3
+          refresh-interval = 5 minutes
+          // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
+        }
+      }
+      # The node-level metrics (all disabled by default).
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      node {
+        enabled = [
+          # The number of connections open to this node for regular requests (exposed as a
+          # Gauge<Integer>).
+          #
+          # This includes the control connection (which uses at most one extra connection to a
+          # random node in the cluster).
+          // pool.open-connections,
+
+          # The number of stream ids available on the connections to this node (exposed as a
+          # Gauge<Integer>).
+          #
+          # Stream ids are used to multiplex requests on each connection, so this is an indication
+          # of how many more requests the node could handle concurrently before becoming saturated
+          # (note that this is a driver-side only consideration, there might be other limitations on
+          # the server that prevent reaching that theoretical limit).
+          // pool.available-streams,
+
+          # The number of requests currently executing on the connections to this node (exposed as a
+          # Gauge<Integer>). This includes orphaned streams.
+          // pool.in-flight,
+
+          # The number of "orphaned" stream ids on the connections to this node (exposed as a
+          # Gauge<Integer>).
+          #
+          # See the description of the connection.max-orphan-requests option for more details.
+          // pool.orphaned-streams,
+
+          # The number and rate of bytes sent to this node (exposed as a Meter if available, otherwise
+          # as a Counter).
+          // bytes-sent,
+
+          # The number and rate of bytes received from this node (exposed as a Meter if available,
+          # otherwise as a Counter).
+          // bytes-received,
+
+          # The throughput and latency percentiles of individual CQL messages sent to this node as
+          # part of an overall request (exposed as a Timer).
+          #
+          # Note that this does not necessarily correspond to the overall duration of the
+          # session.execute() call, since the driver might query multiple nodes because of retries
+          # and speculative executions. Therefore a single "request" (as seen from a client of the
+          # driver) can be composed of more than one of the "messages" measured by this metric.
+          #
+          # Therefore this metric is intended as an insight into the performance of this particular
+          # node. For statistics on overall request completion, use the session-level cql-requests.
+          // cql-messages,
+
+          # The number of times the driver failed to send a request to this node (exposed as a
+          # Counter).
+          #
+          # In those case we know the request didn't even reach the coordinator, so they are retried
+          # on the next node automatically (without going through the retry policy).
+          // errors.request.unsent,
+
+          # The number of times a request was aborted before the driver even received a response
+          # from this node (exposed as a Counter).
+          #
+          # This can happen in two cases: if the connection was closed due to an external event
+          # (such as a network error or heartbeat failure); or if there was an unexpected error
+          # while decoding the response (this can only be a driver bug).
+          // errors.request.aborted,
+
+          # The number of times this node replied with a WRITE_TIMEOUT error (exposed as a Counter).
+          #
+          # Whether this error is rethrown directly to the client, rethrown or ignored is determined
+          # by the RetryPolicy.
+          // errors.request.write-timeouts,
+
+          # The number of times this node replied with a READ_TIMEOUT error (exposed as a Counter).
+          #
+          # Whether this error is rethrown directly to the client, rethrown or ignored is determined
+          # by the RetryPolicy.
+          // errors.request.read-timeouts,
+
+          # The number of times this node replied with an UNAVAILABLE error (exposed as a Counter).
+          #
+          # Whether this error is rethrown directly to the client, rethrown or ignored is determined
+          # by the RetryPolicy.
+          // errors.request.unavailables,
+
+          # The number of times this node replied with an error that doesn't fall under other
+          # 'errors.*' metrics (exposed as a Counter).
+          // errors.request.others,
+
+          # The total number of errors on this node that caused the RetryPolicy to trigger a retry
+          # (exposed as a Counter).
+          #
+          # This is a sum of all the other retries.* metrics.
+          // retries.total,
+
+          # The number of errors on this node that caused the RetryPolicy to trigger a retry, broken
+          # down by error type (exposed as Counters).
+          // retries.aborted,
+          // retries.read-timeout,
+          // retries.write-timeout,
+          // retries.unavailable,
+          // retries.other,
+
+          # The total number of errors on this node that were ignored by the RetryPolicy (exposed as
+          # a Counter).
+          #
+          # This is a sum of all the other ignores.* metrics.
+          // ignores.total,
+
+          # The number of errors on this node that were ignored by the RetryPolicy, broken down by
+          # error type (exposed as Counters).
+          // ignores.aborted,
+          // ignores.read-timeout,
+          // ignores.write-timeout,
+          // ignores.unavailable,
+          // ignores.other,
+
+          # The number of speculative executions triggered by a slow response from this node
+          # (exposed as a Counter).
+          // speculative-executions,
+
+          # The number of errors encountered while trying to establish a connection to this node
+          # (exposed as a Counter).
+          #
+          # Connection errors are not a fatal issue for the driver, failed connections will be
+          # retried periodically according to the reconnection policy. You can choose whether or not
+          # to log those errors at WARN level with the connection.warn-on-init-error option.
+          #
+          # Authentication errors are not included in this counter, they are tracked separately in
+          # errors.connection.auth.
+          // errors.connection.init,
+
+          # The number of authentication errors encountered while trying to establish a connection
+          # to this node (exposed as a Counter).
+          # Authentication errors are also logged at WARN level.
+          // errors.connection.auth,
+
+          # The throughput and latency percentiles of individual graph messages sent to this node as
+          # part of an overall request (exposed as a Timer).
+          #
+          # Note that this does not necessarily correspond to the overall duration of the
+          # session.execute() call, since the driver might query multiple nodes because of retries
+          # and speculative executions. Therefore a single "request" (as seen from a client of the
+          # driver) can be composed of more than one of the "messages" measured by this metric.
+          #
+          # Therefore this metric is intended as an insight into the performance of this particular
+          # node. For statistics on overall request completion, use the session-level graph-requests.
+          // graph-messages,
+        ]
+
+        # See cql-requests in the `session` section
+        #
+        # Required: if the 'cql-messages' metric is enabled, and Dropwizard or Micrometer is used.
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        cql-messages {
+          highest-latency = 3 seconds
+          lowest-latency = 1 millisecond
+          significant-digits = 3
+          refresh-interval = 5 minutes
+          // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
+        }
+
+        # See graph-requests in the `session` section
+        #
+        # Required: if the 'graph-messages' metric is enabled, and Dropwizard or Micrometer is used.
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        graph-messages {
+          highest-latency = 3 seconds
+          lowest-latency = 1 millisecond
+          significant-digits = 3
+          refresh-interval = 5 minutes
+          // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
+        }
+
+        # The time after which the node level metrics will be evicted.
+        #
+        # This is used to unregister stale metrics if a node leaves the cluster or gets a new address.
+        # If the node does not come back up when this interval elapses, all its metrics are removed
+        # from the registry.
+        #
+        # The lowest allowed value is 5 minutes. If you try to set it lower, the driver will log a
+        # warning and use 5 minutes.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        expire-after = 1 hour
+      }
+    }
+
+    socket {
+      # Whether or not to disable the Nagle algorithm.
+      #
+      # By default, this option is set to true (Nagle disabled), because the driver has its own
+      # internal message coalescing algorithm.
+      #
+      # See java.net.StandardSocketOptions.TCP_NODELAY.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      tcp-no-delay = true
+
+      # All other socket options are unset by default. The actual value depends on the underlying
+      # Netty transport:
+      # - NIO uses the defaults from java.net.Socket (refer to the javadocs of
+      #   java.net.StandardSocketOptions for each option).
+      # - Epoll delegates to the underlying file descriptor, which uses the O/S defaults.
+
+      # Whether or not to enable TCP keep-alive probes.
+      #
+      # See java.net.StandardSocketOptions.SO_KEEPALIVE.
+      #
+      # Required: no
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      //keep-alive = false
+
+      # Whether or not to allow address reuse.
+      #
+      # See java.net.StandardSocketOptions.SO_REUSEADDR.
+      #
+      # Required: no
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      //reuse-address = true
+
+      # Sets the linger interval.
+      #
+      # If the value is zero or greater, then it represents a timeout value, in seconds;
+      # if the value is negative, it means that this option is disabled.
+      #
+      # See java.net.StandardSocketOptions.SO_LINGER.
+      #
+      # Required: no
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      //linger-interval = 0
+
+      # Sets a hint to the size of the underlying buffers for incoming network I/O.
+      #
+      # See java.net.StandardSocketOptions.SO_RCVBUF.
+      #
+      # Required: no
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      //receive-buffer-size = 65535
+
+      # Sets a hint to the size of the underlying buffers for outgoing network I/O.
+      #
+      # See java.net.StandardSocketOptions.SO_SNDBUF.
+      #
+      # Required: no
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      //send-buffer-size = 65535
+    }
+
+    heartbeat {
+      # The heartbeat interval. If a connection stays idle for that duration (no reads), the driver
+      # sends a dummy message on it to make sure it's still alive. If not, the connection is trashed
+      # and replaced.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      interval = 30 seconds
+
+      # How long the driver waits for the response to a heartbeat. If this timeout fires, the
+      # heartbeat is considered failed.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for connections created after the
+      #   change.
+      # Overridable in a profile: no
+      # timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+    }
+
+    metadata {
+      # Topology events are external signals that inform the driver of the state of Cassandra nodes
+      # (by default, they correspond to gossip events received on the control connection).
+      # The debouncer helps smoothen out oscillations if conflicting events are sent out in short
+      # bursts.
+      # Debouncing may be disabled by setting the window to 0 or max-events to 1 (this is not
+      # recommended).
+      topology-event-debouncer {
+        # How long the driver waits to propagate an event. If another event is received within that
+        # time, the window is reset and a batch of accumulated events will be delivered.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        window = 1 second
+
+        # The maximum number of events that can accumulate. If this count is reached, the events are
+        # delivered immediately and the time window is reset. This avoids holding events indefinitely
+        # if the window keeps getting reset.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        max-events = 20
+      }
+
+      # Options relating to schema metadata (Cluster.getMetadata.getKeyspaces).
+      # This metadata is exposed by the driver for informational purposes, and is also necessary for
+      # token-aware routing.
+      schema {
+        # Whether schema metadata is enabled.
+        # If this is false, the schema will remain empty, or to the last known value.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
+        #   change. It can also be overridden programmatically via Cluster.setSchemaMetadataEnabled.
+        # Overridable in a profile: no
+        enabled = true
+
+        # The keyspaces for which schema and token metadata should be maintained.
+        #
+        # Each element can be one of the following:
+        # 1. An exact name inclusion, for example "Ks1". If the name is case-sensitive, it must appear
+        #    in its exact case.
+        # 2. An exact name exclusion, for example "!Ks1".
+        # 3. A regex inclusion, enclosed in slashes, for example "/^Ks.*/". The part between the
+        #    slashes must follow the syntax rules of java.util.regex.Pattern.
+        # 4. A regex exclusion, for example "!/^Ks.*/".
+        #
+        # If the list is empty, or the option is unset, all keyspaces will match. Otherwise:
+        #
+        # If a keyspace matches an exact name inclusion, it is always included, regardless of what any
+        # other rule says.
+        # Otherwise, if it matches an exact name exclusion, it is always excluded, regardless of what
+        # any regex rule says.
+        # Otherwise, if there are regex rules:
+        # - if they're only inclusions, the keyspace must match at least one of them.
+        # - if they're only exclusions, the keyspace must match none of them.
+        # - if they're both, the keyspace must match at least one inclusion and none of the
+        #   exclusions.
+        #
+        # If an element is malformed, or if its regex has a syntax error, a warning is logged and that
+        # single element is ignored.
+        #
+        # Try to use only exact name inclusions if possible. This allows the driver to filter on the
+        # server side with a WHERE IN clause. If you use any other rule, it has to fetch all system
+        # rows and filter on the client side.
+        #
+        # Required: no. The default value excludes all Cassandra and DSE system keyspaces. If the
+        #   option is unset, this is interpreted as "include all keyspaces".
+        # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
+        #   change.
+        # Overridable in a profile: no
+        refreshed-keyspaces = [ "!system", "!/^system_.*/", "!/^dse_.*/", "!solr_admin", "!OpsCenter" ]
+
+        # The timeout for the requests to the schema tables.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
+        #   change.
+        # Overridable in a profile: no
+        request-timeout = ${datastax-java-driver.basic.request.timeout}
+
+        # The page size for the requests to the schema tables.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
+        #   change.
+        # Overridable in a profile: no
+        request-page-size = ${datastax-java-driver.basic.request.page-size}
+
+        # Protects against bursts of schema updates (for example when a client issues a sequence of
+        # DDL queries), by coalescing them into a single update.
+        # Debouncing may be disabled by setting the window to 0 or max-events to 1 (this is highly
+        # discouraged for schema refreshes).
+        debouncer {
+          # How long the driver waits to apply a refresh. If another refresh is requested within that
+          # time, the window is reset and a single refresh will be triggered when it ends.
+          #
+          # Required: yes
+          # Modifiable at runtime: no
+          # Overridable in a profile: no
+          window = 1 second
+
+          # The maximum number of refreshes that can accumulate. If this count is reached, a refresh
+          # is done immediately and the window is reset.
+          #
+          # Required: yes
+          # Modifiable at runtime: no
+          # Overridable in a profile: no
+          max-events = 20
+        }
+      }
+
+      # Whether token metadata (Cluster.getMetadata.getTokenMap) is enabled.
+      # This metadata is exposed by the driver for informational purposes, and is also necessary for
+      # token-aware routing.
+      # If this is false, it will remain empty, or to the last known value. Note that its computation
+      # requires information about the schema; therefore if schema metadata is disabled or filtered to
+      # a subset of keyspaces, the token map will be incomplete, regardless of the value of this
+      # property.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for refreshes issued after the change.
+      # Overridable in a profile: no
+      token-map.enabled = true
+    }
+
+    control-connection {
+      # How long the driver waits for responses to control queries (e.g. fetching the list of nodes,
+      # refreshing the schema).
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      # timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+
+      # Due to the distributed nature of Cassandra, schema changes made on one node might not be
+      # immediately visible to others. Under certain circumstances, the driver waits until all nodes
+      # agree on a common schema version (namely: before a schema refresh, before repreparing all
+      # queries on a newly up node, and before completing a successful schema-altering query). To do
+      # so, it queries system tables to find out the schema version of all nodes that are currently
+      # UP. If all the versions match, the check succeeds, otherwise it is retried periodically, until
+      # a given timeout.
+      #
+      # A schema agreement failure is not fatal, but it might produce unexpected results (for example,
+      # getting an "unconfigured table" error for a table that you created right before, just because
+      # the two queries went to different coordinators).
+      #
+      # Note that schema agreement never succeeds in a mixed-version cluster (it would be challenging
+      # because the way the schema version is computed varies across server versions); the assumption
+      # is that schema updates are unlikely to happen during a rolling upgrade anyway.
+      schema-agreement {
+        # The interval between each attempt.
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for checks issued after the change.
+        # Overridable in a profile: no
+        interval = 200 milliseconds
+
+        # The timeout after which schema agreement fails.
+        # If this is set to 0, schema agreement is skipped and will always fail.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for checks issued after the change.
+        # Overridable in a profile: no
+        timeout = 10 seconds
+
+        # Whether to log a warning if schema agreement fails.
+        # You might want to change this if you've set the timeout to 0.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for checks issued after the change.
+        # Overridable in a profile: no
+        warn-on-failure = true
+      }
+    }
+
+    prepared-statements {
+      # Whether `Session.prepare` calls should be sent to all nodes in the cluster.
+      #
+      # A request to prepare is handled in two steps:
+      # 1) send to a single node first (to rule out simple errors like malformed queries).
+      # 2) if step 1 succeeds, re-send to all other active nodes (i.e. not ignored by the load
+      # balancing policy).
+      # This option controls whether step 2 is executed.
+      #
+      # The reason why you might want to disable it is to optimize network usage if you have a large
+      # number of clients preparing the same set of statements at startup. If your load balancing
+      # policy distributes queries randomly, each client will pick a different host to prepare its
+      # statements, and on the whole each host has a good chance of having been hit by at least one
+      # client for each statement.
+      # On the other hand, if that assumption turns out to be wrong and one host hasn't prepared a
+      # given statement, it needs to be re-prepared on the fly the first time it gets executed; this
+      # causes a performance penalty (one extra roundtrip to resend the query to prepare, and another
+      # to retry the execution).
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for prepares issued after the change.
+      # Overridable in a profile: yes
+      prepare-on-all-nodes = true
+
+      # How the driver replicates prepared statements on a node that just came back up or joined the
+      # cluster.
+      reprepare-on-up {
+        # Whether the driver tries to prepare on new nodes at all.
+        #
+        # The reason why you might want to disable it is to optimize reconnection time when you
+        # believe nodes often get marked down because of temporary network issues, rather than the
+        # node really crashing. In that case, the node still has prepared statements in its cache when
+        # the driver reconnects, so re-preparing is redundant.
+        #
+        # On the other hand, if that assumption turns out to be wrong and the node had really
+        # restarted, its prepared statement cache is empty (before CASSANDRA-8831), and statements
+        # need to be re-prepared on the fly the first time they get executed; this causes a
+        # performance penalty (one extra roundtrip to resend the query to prepare, and another to
+        # retry the execution).
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+        #   change.
+        # Overridable in a profile: no
+        enabled = true
+
+        # Whether to check `system.prepared_statements` on the target node before repreparing.
+        #
+        # This table exists since CASSANDRA-8831 (merged in 3.10). It stores the statements already
+        # prepared on the node, and preserves them across restarts.
+        #
+        # Checking the table first avoids repreparing unnecessarily, but the cost of the query is not
+        # always worth the improvement, especially if the number of statements is low.
+        #
+        # If the table does not exist, or the query fails for any other reason, the error is ignored
+        # and the driver proceeds to reprepare statements according to the other parameters.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+        #   change.
+        # Overridable in a profile: no
+        check-system-table = false
+
+        # The maximum number of statements that should be reprepared. 0 or a negative value means no
+        # limit.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+        #   change.
+        # Overridable in a profile: no
+        max-statements = 0
+
+        # The maximum number of concurrent requests when repreparing.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+        #   change.
+        # Overridable in a profile: no
+        max-parallelism = 100
+
+        # The request timeout. This applies both to querying the system.prepared_statements table (if
+        # relevant), and the prepare requests themselves.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+        #   change.
+        # Overridable in a profile: no
+        # timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+      }
+
+      # How to build the cache of prepared statements.
+      prepared-cache {
+        # Whether to use weak references for the prepared statements cache values.
+        #
+        # If this option is absent, weak references will be used.
+        #
+        # Required: no
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        // weak-values = true
+      }
+    }
+
+    # Options related to the Netty event loop groups used internally by the driver.
+    netty {
+
+      # Whether the threads created by the driver should be daemon threads.
+      # This will apply to the threads in io-group, admin-group, and the timer thread.
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      daemon = false
+
+      # The event loop group used for I/O operations (reading and writing to Cassandra nodes).
+      # By default, threads in this group are named after the session name, "-io-" and an incrementing
+      # counter, for example "s0-io-0".
+      io-group {
+        # The number of threads.
+        # If this is set to 0, the driver will use `Runtime.getRuntime().availableProcessors() * 2`.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        size = 0
+
+        # The options to shut down the event loop group gracefully when the driver closes. If a task
+        # gets submitted during the quiet period, it is accepted and the quiet period starts over.
+        # The timeout limits the overall shutdown time.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        shutdown {quiet-period = 2, timeout = 15, unit = SECONDS}
+      }
+      # The event loop group used for admin tasks not related to request I/O (handle cluster events,
+      # refresh metadata, schedule reconnections, etc.)
+      # By default, threads in this group are named after the session name, "-admin-" and an
+      # incrementing counter, for example "s0-admin-0".
+      admin-group {
+        size = 2
+
+        shutdown {quiet-period = 2, timeout = 15, unit = SECONDS}
+      }
+      # The timer used for scheduling request timeouts and speculative executions
+      # By default, this thread is named after the session name and "-timer-0", for example
+      # "s0-timer-0".
+      timer {
+        # The timer tick duration.
+        # This is how frequent the timer should wake up to check for timed-out tasks or speculative
+        # executions. Lower resolution (i.e. longer durations) will leave more CPU cycles for running
+        # I/O operations at the cost of precision of exactly when a request timeout will expire or a
+        # speculative execution will run. Higher resolution (i.e. shorter durations) will result in
+        # more precise request timeouts and speculative execution scheduling, but at the cost of CPU
+        # cycles taken from I/O operations, which could lead to lower overall I/O throughput.
+        #
+        # The default value is 100 milliseconds, which is a comfortable value for most use cases.
+        # However if you are using more agressive timeouts or speculative execution delays, then you
+        # should lower the timer tick duration as well, so that its value is always equal to or lesser
+        # than the timeout duration and/or speculative execution delay you intend to use.
+        #
+        # Note for Windows users: avoid setting this to aggressive values, that is, anything under 100
+        # milliseconds; doing so is known to cause extreme CPU usage. Also, the tick duration must be
+        # a multiple of 10 under Windows; if that is not the case, it will be automatically rounded
+        # down to the nearest multiple of 10 (e.g. 99 milliseconds will be rounded down to 90
+        # milliseconds).
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        tick-duration = 100 milliseconds
+
+        # Number of ticks in a Timer wheel. The underlying implementation uses Netty's
+        # HashedWheelTimer, which uses hashes to arrange the timeouts. This effectively controls the
+        # size of the timer wheel.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        ticks-per-wheel = 2048
+      }
+    }
+
+    # The component that coalesces writes on the connections.
+    # This is exposed mainly to facilitate tuning during development. You shouldn't have to adjust
+    # this.
+    coalescer {
+      # The reschedule interval.
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      reschedule-interval = 10 microseconds
+    }
+  }
+}

--- a/backfill-cli/src/main/resources/logback.xml
+++ b/backfill-cli/src/main/resources/logback.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+    <logger name="com.datastax.oss.cdc" level="INFO"/>
+    <logger name="com.datastax.oss.dsbulk" level="WARN"/>
+    <logger name="com.datastax.oss.driver" level="WARN"/>
+    <logger name="com.datastax.dse.driver" level="WARN"/>
+</configuration>

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,8 @@ subprojects {
         excludes([ "**/cassandra.yaml",
                    "**/logback*",
                    '**/cassandra-source-version.properties',
-                   '**/source-cassandra-*'
+                   '**/source-cassandra-*',
+                   '**/command_factory.yml',
         ])
     }
 


### PR DESCRIPTION
This patch adds initial support for running `backfill-cli` as a pulsar admin extension. I tested the happy path locally using the LS2.10_3 tarball:
```
bin/pulsar-admin cassandra-cdc backfill --data-dir target/export --export-host 127.0.0.1:9042 --export-username cassandra --export-password cassandra --keyspace ks1 --table sample4
```

in the `client.conf` I added the following line:
```
customCommandFactories=cassandra-cdc
```

**Implementation notes:** 
* Added few DSBulk workarounds to make it class loader aware, and to have it run with a log4j log implementation. For more regarding the long term solution, please check https://github.com/datastax/dsbulk/issues/465 & https://github.com/datastax/dsbulk/issues/466
* Added a nar file task to be used as a pulsar admin extention
* Added basic CustomCommandFactory to show the happy path. This will be extended shortly with
  * `client.conf` settings related to pulsar client authentication
  * The exhaustive list of options avaible on the backfill CLI
* The backfill cli supports java 8 and 11 for now, and will not work as a pulsar admin extension with Pulsar 2.11 for example.  