### PR TITLE
Use the backfill pulsar admin ext for e2e tests

### DIFF
--- a/backfill-cli/build.gradle
+++ b/backfill-cli/build.gradle
@@ -97,6 +97,8 @@ dependencies {
 
 // Custom nar task that wraps the shadowJar for pulsar admin extension purposes.
 tasks.register('nar', Zip) {
+    dependsOn shadowJar
+
     // bundle the shadow jar as is
     from(shadowJar.archivePath) {
         into "META-INF/bundled-dependencies"
@@ -110,6 +112,9 @@ tasks.register('nar', Zip) {
             into "META-INF" + relativeParentDir
         }
     }
+
+    // explicitly include all files in the resources folder, otherwise the shadowJar will not include them
+    sourceSets.main.resources.include("**/*")
 
     archiveName "pulsar-cassandra-admin-${project.version}-nar.nar"
     destinationDir file("${buildDir}/libs")
@@ -127,7 +132,6 @@ task e2eTest(type: Test) {
     testLogging.showStandardStreams = true
 
     dependsOn project(':connector').assemble // couldn't take dependency on nar directly
-    dependsOn shadowJar
     dependsOn nar
 
     useJUnitPlatform()

--- a/backfill-cli/build.gradle
+++ b/backfill-cli/build.gradle
@@ -128,6 +128,7 @@ task e2eTest(type: Test) {
 
     dependsOn project(':connector').assemble // couldn't take dependency on nar directly
     dependsOn shadowJar
+    dependsOn nar
 
     useJUnitPlatform()
 

--- a/backfill-cli/build.gradle
+++ b/backfill-cli/build.gradle
@@ -73,6 +73,8 @@ dependencies {
     implementation "com.datastax.oss:dsbulk-connectors-csv:${dsbulkVersion}"
     implementation "com.datastax.oss:dsbulk-executor-reactor:${dsbulkVersion}"
     implementation "com.datastax.oss:dsbulk-batcher-reactor:${dsbulkVersion}"
+    implementation "com.datastax.oss:dsbulk-codecs-api:${dsbulkVersion}"
+    implementation "com.datastax.oss:dsbulk-codecs-text:${dsbulkVersion}"
     implementation "com.google.guava:guava:${guavaVersion}"
 
     implementation "info.picocli:picocli:4.7.1"

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/admin/BackfillCommand.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/admin/BackfillCommand.java
@@ -16,7 +16,6 @@
 
 package com.datastax.oss.cdc.backfill.admin;
 
-import com.amazonaws.transform.MapEntry;
 import com.datastax.oss.cdc.backfill.BackfillCLI;
 import org.apache.pulsar.admin.cli.extensions.CommandExecutionContext;
 import org.apache.pulsar.admin.cli.extensions.CustomCommand;

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/factory/CodecFactory.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/factory/CodecFactory.java
@@ -1,2 +1,26 @@
-package com.datastax.oss.cdc.backfill.factory;public class CodecFactory {
+package com.datastax.oss.cdc.backfill.factory;
+
+import com.datastax.oss.dsbulk.codecs.api.ConvertingCodecFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Class loader aware converting codec factory.
+ */
+@NotThreadSafe
+public class CodecFactory {
+    /**
+     * Works around the dsbulk codec factory limitation that uses the class-loader unaware ServiceLoader.load() API
+     * which defaults to Thread.currentThread().getContextClassLoader(). This will lead to class loading issues when
+     * ruing as a NAR archive.
+     */
+    public ConvertingCodecFactory newCodecFactory(ClassLoader classLoader) {
+        ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return new ConvertingCodecFactory();
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldClassLoader);
+        }
+    }
 }

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/factory/CodecFactory.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/factory/CodecFactory.java
@@ -1,0 +1,2 @@
+package com.datastax.oss.cdc.backfill.factory;public class CodecFactory {
+}

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/factory/CodecFactory.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/factory/CodecFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.datastax.oss.cdc.backfill.factory;
 
 import com.datastax.oss.dsbulk.codecs.api.ConvertingCodecFactory;

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/importer/PulsarImporter.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/importer/PulsarImporter.java
@@ -22,6 +22,7 @@ import com.datastax.oss.cdc.agent.PulsarMutationSender;
 import com.datastax.oss.cdc.agent.exceptions.CassandraConnectorSchemaException;
 import com.datastax.oss.cdc.backfill.ExitStatus;
 import com.datastax.oss.cdc.backfill.exporter.ExportedTable;
+import com.datastax.oss.cdc.backfill.factory.CodecFactory;
 import com.datastax.oss.cdc.backfill.factory.ConnectorFactory;
 import com.datastax.oss.cdc.backfill.factory.PulsarMutationSenderFactory;
 import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
@@ -99,7 +100,8 @@ public class PulsarImporter {
      * node. Doesn't apply for CDC back-filling.
      */
     private final static UUID MUTATION_NODE = null;
-    private final static ConvertingCodecFactory codecFactory = new ConvertingCodecFactory();
+    private final static ConvertingCodecFactory codecFactory =
+            new CodecFactory().newCodecFactory(PulsarImporter.class.getClassLoader());
 
     /**
      * The maximum number of in-flight pulsar messages currently being imported
@@ -110,10 +112,11 @@ public class PulsarImporter {
     private final AtomicInteger sentMutations = new AtomicInteger(0);
     private final AtomicInteger sentErrors = new AtomicInteger(0);
 
-    public PulsarImporter(ConnectorFactory connectorFactory, ExportedTable exportedTable, PulsarMutationSenderFactory factory) {
+    public PulsarImporter(ConnectorFactory connectorFactory, ExportedTable exportedTable,
+                          PulsarMutationSenderFactory mutationSenderFactory) {
         this.connectorFactory = connectorFactory;
         this.exportedTable = exportedTable;
-        this.mutationSender = factory.newPulsarMutationSender();
+        this.mutationSender = mutationSenderFactory.newPulsarMutationSender();
         this.inflightPulsarMessages = new Semaphore(MAX_INFLIGHT_MESSAGES_PER_TASK_SETTING);
     }
 

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/PulsarImporterTest.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/PulsarImporterTest.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.db.marshal.IntegerType;
 import org.apache.cassandra.db.marshal.SimpleDateType;
 import org.apache.cassandra.db.marshal.TimeType;
+import org.apache.cassandra.db.marshal.TimestampType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
@@ -155,6 +156,8 @@ public class PulsarImporterTest {
                 new ColumnIdentifier("xdate", true);
         ColumnIdentifier xblobIdentifier =
                 new ColumnIdentifier("xblob", true);
+        ColumnIdentifier xtimestampIdentifier =
+                new ColumnIdentifier("xtimestamp", true);
         ColumnMetadata xintColumnMetadata =
                 new ColumnMetadata("ks1", "xint", xintIdentifier, IntegerType.instance, 2, ColumnMetadata.Kind.CLUSTERING);
         ColumnMetadata xtimeColumnMetadata =
@@ -163,12 +166,15 @@ public class PulsarImporterTest {
                 new ColumnMetadata("ks1", "xdate", xdateIdentifier, SimpleDateType.instance, 4, ColumnMetadata.Kind.CLUSTERING);
         ColumnMetadata xblobColumnMetadata =
                 new ColumnMetadata("ks1", "xblob", xblobIdentifier, BytesType.instance, 5, ColumnMetadata.Kind.CLUSTERING);
+        ColumnMetadata xtimestampColumnMetadata =
+                new ColumnMetadata("ks1", "xtimestamp", xtimestampIdentifier, TimestampType.instance, 6, ColumnMetadata.Kind.CLUSTERING);
         cassandraColumns.add(xtextColumnMetadata);
         cassandraColumns.add(xbooleanColumnMetadata);
         cassandraColumns.add(xintColumnMetadata);
         cassandraColumns.add(xtimeColumnMetadata);
         cassandraColumns.add(xdateColumnMetadata);
         cassandraColumns.add(xblobColumnMetadata);
+        cassandraColumns.add(xtimestampColumnMetadata);
 
         Mockito.when(tableMetadata.primaryKeyColumns()).thenReturn(cassandraColumns);
 
@@ -180,6 +186,7 @@ public class PulsarImporterTest {
         columns.add(new DefaultColumnMetadata(CqlIdentifier.fromInternal("ks1"), CqlIdentifier.fromInternal("table1"), CqlIdentifier.fromInternal("xtime"), DataTypes.TIME, false));
         columns.add(new DefaultColumnMetadata(CqlIdentifier.fromInternal("ks1"), CqlIdentifier.fromInternal("table1"), CqlIdentifier.fromInternal("xdate"), DataTypes.DATE, false));
         columns.add(new DefaultColumnMetadata(CqlIdentifier.fromInternal("ks1"), CqlIdentifier.fromInternal("table1"), CqlIdentifier.fromInternal("xblob"), DataTypes.BLOB, false));
+        columns.add(new DefaultColumnMetadata(CqlIdentifier.fromInternal("ks1"), CqlIdentifier.fromInternal("table1"), CqlIdentifier.fromInternal("xtimestamp"), DataTypes.TIMESTAMP, false));
         Mockito.when(exportedTable.getPrimaryKey()).thenReturn(columns);
 
         // when

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
@@ -115,6 +116,9 @@ public class BackfillCLIE2ETests {
                 .withFileSystemBind(
                         String.format(Locale.ROOT, "%s/libs/%s", connectorBuildDir, backfillNarFile),
                         String.format(Locale.ROOT, "/pulsar/connectors/%s", backfillNarFile))
+                .withClasspathResourceMapping("redis.conf",
+                        "/pulsar/conf/client.conf",
+                        BindMode.READ_ONLY)
                 .withStartupTimeout(Duration.ofSeconds(60));
         pulsarContainer.start();
 

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
@@ -65,6 +65,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -116,7 +117,7 @@ public class BackfillCLIE2ETests {
                 .withFileSystemBind(
                         String.format(Locale.ROOT, "%s/libs/%s", connectorBuildDir, backfillNarFile),
                         String.format(Locale.ROOT, "/pulsar/connectors/%s", backfillNarFile))
-                .withClasspathResourceMapping("redis.conf",
+                .withClasspathResourceMapping("client.conf",
                         "/pulsar/conf/client.conf",
                         BindMode.READ_ONLY)
                 .withStartupTimeout(Duration.ofSeconds(60));
@@ -379,14 +380,14 @@ public class BackfillCLIE2ETests {
     private void runBackfillAsync(String ksName, String tableName) {
         new Thread(() -> {
             try {
-                String[] bacfillCommand = new String[] {
+                String[] backfillCommand = new String[] {
                         "/pulsar/bin/pulsar-admin", "cassandra-cdc", "backfill", "--data-dir", dataDir.toString(),
                         "--export-host", cassandraContainer1.getCqlHostAddress(), "--keyspace", ksName, "--table",
                         tableName, "--export-consistency", "LOCAL_QUORUM"
                 };
-                log.info("Running backfill command: {} ", bacfillCommand);
-                Container.ExecResult result = pulsarContainer.execInContainer(bacfillCommand);
-                assertEquals(0, result.getExitCode(), "backfill coomand failed:" + result.getStdout());
+                log.info("Running backfill command: {} ", Arrays.toString(backfillCommand));
+                Container.ExecResult result = pulsarContainer.execInContainer(backfillCommand);
+                assertEquals(0, result.getExitCode(), "backfill command failed:" + result.getStdout());
                 log.info("backfill command finished successfully");
             } catch (InterruptedException | IOException e) {
                 log.error("Failed to run backfilling", e);

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
@@ -104,6 +104,7 @@ public class BackfillCLIE2ETests {
         testNetwork = Network.newNetwork();
 
         String connectorBuildDir = System.getProperty("connectorBuildDir");
+        String cdcBackfillBuildDir = System.getProperty("cdcBackfillBuildDir");
         String projectVersion = System.getProperty("projectVersion");
         String connectorJarFile = String.format(Locale.ROOT, "pulsar-cassandra-source-%s.nar", projectVersion);
         String backfillNarFile =  String.format(Locale.ROOT, "pulsar-cassandra-admin-%s.nar", projectVersion);
@@ -115,8 +116,8 @@ public class BackfillCLIE2ETests {
                         String.format(Locale.ROOT, "%s/libs/%s", connectorBuildDir, connectorJarFile),
                         String.format(Locale.ROOT, "/pulsar/connectors/%s", connectorJarFile))
                 .withFileSystemBind(
-                        String.format(Locale.ROOT, "%s/libs/%s", connectorBuildDir, backfillNarFile),
-                        String.format(Locale.ROOT, "/pulsar/connectors/%s", backfillNarFile))
+                        String.format(Locale.ROOT, "%s/libs/%s", cdcBackfillBuildDir, backfillNarFile),
+                        String.format(Locale.ROOT, "/pulsar/cliextensions/%s", backfillNarFile))
                 .withClasspathResourceMapping("client.conf",
                         "/pulsar/conf/client.conf",
                         BindMode.READ_ONLY)

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
@@ -383,12 +383,13 @@ public class BackfillCLIE2ETests {
             try {
                 String[] backfillCommand = new String[] {
                         "/pulsar/bin/pulsar-admin", "cassandra-cdc", "backfill", "--data-dir", dataDir.toString(),
-                        "--export-host", cassandraContainer1.getCqlHostAddress(), "--keyspace", ksName, "--table",
+                        "--export-host", "cassandra-1", "--keyspace", ksName, "--table",
                         tableName, "--export-consistency", "LOCAL_QUORUM"
                 };
                 log.info("Running backfill command: {} ", Arrays.toString(backfillCommand));
                 Container.ExecResult result = pulsarContainer.execInContainer(backfillCommand);
                 assertEquals(0, result.getExitCode(), "backfill command failed:" + result.getStdout());
+                log.info(result.getStdout());
                 log.info("backfill command finished successfully");
             } catch (InterruptedException | IOException e) {
                 log.error("Failed to run backfilling", e);

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
@@ -107,7 +107,7 @@ public class BackfillCLIE2ETests {
         String cdcBackfillBuildDir = System.getProperty("cdcBackfillBuildDir");
         String projectVersion = System.getProperty("projectVersion");
         String connectorJarFile = String.format(Locale.ROOT, "pulsar-cassandra-source-%s.nar", projectVersion);
-        String backfillNarFile =  String.format(Locale.ROOT, "pulsar-cassandra-admin-%s.nar", projectVersion);
+        String backfillNarFile =  String.format(Locale.ROOT, "pulsar-cassandra-admin-%s-nar.nar", projectVersion);
         pulsarContainer = new PulsarContainer<>(PULSAR_IMAGE)
                 .withNetwork(testNetwork)
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("pulsar"))

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
@@ -126,7 +126,7 @@ public class BackfillCLIE2ETests {
         // ./pulsar-admin namespaces set-auto-topic-creation public/default --enable --type partitioned --num-partitions 1
         Container.ExecResult result = pulsarContainer.execInContainer(
                 "/pulsar/bin/pulsar-admin", "namespaces", "set-auto-topic-creation", "public/default", "--enable");
-        assertEquals(0, result.getExitCode(), result.getStdout());
+        assertEquals(0, result.getExitCode(), "Failed to set auto topic create " + result.getStdout() + " " + result.getStderr());
         result = pulsarContainer.execInContainer(
                 "/pulsar/bin/pulsar-admin", "namespaces", "set-is-allow-auto-update-schema", "public/default", "--enable");
         assertEquals(0, result.getExitCode(), result.getStdout());

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
@@ -126,10 +126,10 @@ public class BackfillCLIE2ETests {
         // ./pulsar-admin namespaces set-auto-topic-creation public/default --enable --type partitioned --num-partitions 1
         Container.ExecResult result = pulsarContainer.execInContainer(
                 "/pulsar/bin/pulsar-admin", "namespaces", "set-auto-topic-creation", "public/default", "--enable");
-        assertEquals(0, result.getExitCode());
+        assertEquals(0, result.getExitCode(), result.getStdout());
         result = pulsarContainer.execInContainer(
                 "/pulsar/bin/pulsar-admin", "namespaces", "set-is-allow-auto-update-schema", "public/default", "--enable");
-        assertEquals(0, result.getExitCode());
+        assertEquals(0, result.getExitCode(), result.getStdout());
 
         String pulsarServiceUrl = "pulsar://pulsar:" + pulsarContainer.BROKER_PORT;
         String cassandraFamily = System.getProperty("cassandraFamily");

--- a/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
+++ b/backfill-cli/src/test/java/com/datastax/oss/cdc/backfill/e2e/BackfillCLIE2ETests.java
@@ -24,7 +24,6 @@ import com.datastax.testcontainers.PulsarContainer;
 import com.datastax.testcontainers.cassandra.CassandraContainer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -55,9 +54,7 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;

--- a/backfill-cli/src/test/resources/client.conf
+++ b/backfill-cli/src/test/resources/client.conf
@@ -1,0 +1,15 @@
+webServiceUrl=http://localhost:8080/
+brokerServiceUrl=pulsar://localhost:6650/
+authPlugin=
+authParams=
+tlsAllowInsecureConnection=false
+tlsEnableHostnameVerification=false
+tlsTrustCertsFilePath=
+useKeyStoreTls=false
+tlsTrustStoreType=JKS
+tlsTrustStorePath=
+tlsTrustStorePassword=
+webserviceTlsProvider=
+
+# Pulsar Admin Custom Commands
+customCommandFactories=cassandra-cdc

--- a/backfill-cli/src/test/resources/sample-002.csv
+++ b/backfill-cli/src/test/resources/sample-002.csv
@@ -1,3 +1,3 @@
-xtext,xboolean,xint,xtime,xdate,xblob
-vtext,1,2,01:02:03,2023-03-02,AAE=
-v2text,0,3,01:02:04,2023-03-01,AQ==
+xtext,xboolean,xint,xtime,xdate,xblob,xtimestamp
+vtext,1,2,01:02:03,2023-03-02,AAE=,2023-03-22T18:16:20.808Z
+v2text,0,3,01:02:04,2023-03-01,AQ==,2022-02-21T18:16:20.808Z

--- a/backfill-cli/src/test/resources/sample-002.csv
+++ b/backfill-cli/src/test/resources/sample-002.csv
@@ -1,3 +1,3 @@
-xtext,xboolean,xint,xtime,xdate,xblob,xtimestamp
-vtext,1,2,01:02:03,2023-03-02,AAE=,2023-03-22T18:16:20.808Z
-v2text,0,3,01:02:04,2023-03-01,AQ==,2022-02-21T18:16:20.808Z
+xtext,xboolean,xint,xtime,xdate,xblob,xtimestamp,xuuid
+vtext,1,2,01:02:03,2023-03-02,AAE=,2023-03-22T18:16:20.808Z,3920dd7d-dcbf-4c2e-bbe5-f300b720ae0d
+v2text,0,3,01:02:04,2023-03-01,AQ==,2022-02-21T18:16:20.807Z,19296adf-fa87-4ba2-bad8-ae86d2769ee6


### PR DESCRIPTION
The patch updates the Cassandra CDC backfill CLI to use the Pulsar Admin CLI Extension for e2e testing. The motivation:
1. The "extension" is the recommend way to run backfilling. 
2. It already exercise the code path that was previously tested if someone where to run the jar directly with the exception of a thin wrapper for the CLI entry point. 

If necessary, we could enable tests on both the JAR and the NAR artifacts but this seems like an overkill for the time being. 

Update: I'll fall back to testing with the JAR when CLI ext is not enabled. 