### PR TITLE
Drop the --export-max-records flag

### DIFF
--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/admin/BackfillCommand.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/admin/BackfillCommand.java
@@ -113,14 +113,6 @@ public class BackfillCommand implements CustomCommand {
         parameters.add(
                 ParameterDescriptor.builder()
                         .description(
-                                "The maximum number of records to export from the table. Must be a positive number or -1. "
-                                        + "The default is -1 (export the entire table).")
-                        .type(ParameterType.INTEGER)
-                        .names(Arrays.asList("--export-max-records"))
-                        .build());
-        parameters.add(
-                ParameterDescriptor.builder()
-                        .description(
                                 "The maximum number of concurrent files to write to. "
                                         + "Must be a positive number or the special value AUTO. The default is AUTO.")
                         .type(ParameterType.STRING)

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/exporter/ExportSettings.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/exporter/ExportSettings.java
@@ -139,15 +139,6 @@ public class ExportSettings {
     public DefaultConsistencyLevel consistencyLevel = DefaultConsistencyLevel.LOCAL_QUORUM;
 
     @Option(
-            names = "--export-max-records",
-            paramLabel = "NUM",
-            description =
-                    "The maximum number of records to export from the table. Must be a positive number or -1. "
-                            + "The default is -1 (export the entire table).",
-            defaultValue = "-1")
-    public int maxRecords = -1;
-
-    @Option(
             names = "--export-max-concurrent-files",
             paramLabel = "NUM|AUTO",
             description =

--- a/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/exporter/TableExporter.java
+++ b/backfill-cli/src/main/java/com/datastax/oss/cdc/backfill/exporter/TableExporter.java
@@ -192,8 +192,6 @@ public class TableExporter {
         }
         args.add("-url");
         args.add(String.valueOf(tableDataDir));
-        args.add("-maxRecords");
-        args.add(String.valueOf(settings.exportSettings.maxRecords));
         args.add("-maxConcurrentFiles");
         args.add(settings.exportSettings.maxConcurrentFiles);
         args.add("-maxConcurrentQueries");


### PR DESCRIPTION
The `--export-max-records` maps to DSBulk -maxRecords flag which is currently not working as expected. Check https://github.com/datastax/dsbulk/issues/470  

For bow, the backfill tool will drop this flag, and will be restored once we sort out the maxRecords. Please note the all DSBulk settings can be still be passed via the `--export-dsbulk-option`