### PR TITLE
img-link

### DIFF
--- a/docs/docs-src/core/modules/ROOT/pages/cdcExample.adoc
+++ b/docs/docs-src/core/modules/ROOT/pages/cdcExample.adoc
@@ -2,9 +2,9 @@
 
 Capture schema changes in your C* tables and pass them to Apache Pulsar(R) with DataStax Change Data Capture (CDC). This doc will guide you through installing, configuring, and using CDC with C* or DSE in a VM-based deployment.
 
-This installation requires the following. Latest version artifacts are available https://github.com/datastax/cdc-apache-cassandra/releases/latest[here^]. Use image:https://img.shields.io/github/v/release/datastax/cdc-apache-cassandra?color=green&display_name=tag:
+This installation requires the following. Latest version artifacts are available https://github.com/datastax/cdc-apache-cassandra/releases/latest[here^]. Use image:https://img.shields.io/github/v/release/datastax/cdc-apache-cassandra?color=green&display_name=tag[link="https://github.com/datastax/cdc-apache-cassandra/releases/latest"^] for the latest version.
 
-* C* or DSE environment 
+* C* or DSE environment
 ** https://downloads.datastax.com/#enterprise[DSE 6.8.16+]
 ** https://cassandra.apache.org/_/download.html[OSS C*]
 * CDC Agent


### PR DESCRIPTION
Syntax for image linking:

This installation requires the following. Latest version artifacts are available https://github.com/datastax/cdc-apache-cassandra/releases/latest[here^]. Use image:https://img.shields.io/github/v/release/datastax/cdc-apache-cassandra?color=green&display_name=tag[link="https://github.com/datastax/cdc-apache-cassandra/releases/latest"^] for the latest version.