### PR TITLE
Improve WatchService error handling & logging

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation("org.apache.avro:avro:${avroVersion}")
     compileOnly("org.slf4j:slf4j-api:${slf4jVersion}")
     testImplementation("org.junit-pioneer:junit-pioneer:1.4.2")
+    testImplementation "com.datastax.oss:dsbulk-tests:${dsbulkVersion}"
 
     implementation("${pulsarGroup}:pulsar-client:${pulsarVersion}")
 }

--- a/agent/src/main/java/com/datastax/oss/cdc/agent/CommitLogProcessor.java
+++ b/agent/src/main/java/com/datastax/oss/cdc/agent/CommitLogProcessor.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
 
 /**
  * Detect and read commitlogs files in the cdc_raw directory.
@@ -36,7 +37,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 public class CommitLogProcessor extends AbstractProcessor implements AutoCloseable {
     private static final String NAME = "Commit Log Processor";
 
-    private static final Set<WatchEvent.Kind<Path>> watchedEvents = Stream.of(ENTRY_CREATE, ENTRY_MODIFY).collect(Collectors.toSet());
+    private static final Set<WatchEvent.Kind<?>> watchedEvents = Stream.of(ENTRY_CREATE, ENTRY_MODIFY, OVERFLOW).collect(Collectors.toSet());
 
     private final AbstractDirectoryWatcher newCommitLogWatcher;
     private final CommitLogTransfer commitLogTransfer;

--- a/agent/src/main/java/com/datastax/oss/cdc/agent/CommitLogReaderService.java
+++ b/agent/src/main/java/com/datastax/oss/cdc/agent/CommitLogReaderService.java
@@ -300,7 +300,7 @@ public abstract class CommitLogReaderService implements Runnable, AutoCloseable
         }
 
         public void cleanup(TaskStatus status) {
-            log.info("Cleanup task={}, status={}", this, status);
+            log.debug("Cleanup task={}, status={}", this, status);
             File file = getFile();
             switch (status) {
                 case SUCCESS:

--- a/agent/src/main/java/com/datastax/oss/cdc/agent/CommitLogReaderService.java
+++ b/agent/src/main/java/com/datastax/oss/cdc/agent/CommitLogReaderService.java
@@ -300,7 +300,7 @@ public abstract class CommitLogReaderService implements Runnable, AutoCloseable
         }
 
         public void cleanup(TaskStatus status) {
-            log.debug("Cleanup task={}", this, status);
+            log.info("Cleanup task={}, status={}", this, status);
             File file = getFile();
             switch (status) {
                 case SUCCESS:

--- a/agent/src/test/java/com/datastax/oss/cdc/agent/AbstractDirectoryWatcherTest.java
+++ b/agent/src/test/java/com/datastax/oss/cdc/agent/AbstractDirectoryWatcherTest.java
@@ -1,0 +1,82 @@
+package com.datastax.oss.cdc.agent;
+
+import com.datastax.oss.dsbulk.tests.utils.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class AbstractDirectoryWatcherTest {
+
+    private Path cdcDir;
+
+    @BeforeEach
+    public void init() throws IOException {
+        cdcDir = Files.createTempDirectory("cdc");
+    }
+
+    @AfterEach
+    void deleteTempDirs() {
+        if (cdcDir != null && Files.exists(cdcDir)) {
+            FileUtils.deleteDirectory(cdcDir);
+        }
+    }
+
+    @Test
+    public void testPoll() throws InterruptedException, IOException {
+        // given
+        Set<WatchEvent.Kind<?>> watchedEvents = Stream.of(ENTRY_CREATE, ENTRY_MODIFY, OVERFLOW).collect(Collectors.toSet());
+        final BlockingQueue<File> commitLogQueue = new LinkedBlockingQueue<>();
+
+        AbstractDirectoryWatcher watcher = new AbstractDirectoryWatcher(cdcDir,
+                Duration.ofSeconds(20), // avoid flakiness, usually completes in ~10 seconds
+                watchedEvents) {
+            @Override
+            void handleEvent(WatchEvent<?> event, Path path) {
+                commitLogQueue.add(path.toFile());
+            }
+        };
+        File commitLog = new File(cdcDir.toFile(), "CommitLog-6-1.log");
+        commitLog.createNewFile();
+
+        // when
+        watcher.poll(); // can block up to 20 seconds
+
+        // then
+        assertEventHandled(commitLogQueue, commitLog);
+
+        // write another file
+        File commitLog2 = new File(cdcDir.toFile(), "CommitLog-6-2.log");
+        commitLog2.createNewFile();
+
+        // when
+        watcher.poll(); // can block up to 20 seconds
+
+        // then
+        assertEventHandled(commitLogQueue, commitLog2);
+    }
+
+    private void assertEventHandled(BlockingQueue<File> commitLogQueue, File expectedFile)  {
+        File actualFile = commitLogQueue.poll();
+        assertNotNull(actualFile);
+        assertEquals(commitLogQueue.size(), 0);
+        assertEquals(expectedFile, actualFile);
+    }
+}

--- a/agent/src/test/java/com/datastax/oss/cdc/agent/AbstractDirectoryWatcherTest.java
+++ b/agent/src/test/java/com/datastax/oss/cdc/agent/AbstractDirectoryWatcherTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.cdc.agent;
 
 import com.datastax.oss.dsbulk.tests.utils.FileUtils;


### PR DESCRIPTION
This patch:
* Ensures `WatchKey#reset()` is called in the case of event handling exception
* Register to and log `java.nio.file.StandardWatchEventKinds.OVERFLOW` if any
* Adds extra logging