### PR TITLE
Release all semaphore permits when the current task instance is to be retried

### DIFF
--- a/agent/src/test/java/com/datastax/oss/cdc/agent/CommitLogReaderServiceTest.java
+++ b/agent/src/test/java/com/datastax/oss/cdc/agent/CommitLogReaderServiceTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.cdc.agent;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class CommitLogReaderServiceTest {
+
+    @Test
+    public void finishTaskRetryTest() throws InterruptedException {
+        // given
+        AgentConfig config = new AgentConfig();
+        config.maxInflightMessagesPerTask = 10;
+        config.cdcConcurrentProcessors = 1;
+        MutationSender<?> mutationSender = Mockito.mock(MutationSender.class);
+        SegmentOffsetWriter segmentOffsetWriter = Mockito.mock(SegmentOffsetWriter.class);
+        CommitLogTransfer commitLogTransfer = Mockito.mock(CommitLogTransfer.class);
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        MyCommitLogService commitLogReaderService = new MyCommitLogService(
+                config, mutationSender, segmentOffsetWriter, commitLogTransfer, executorService);
+        CommitLogReaderService.Task task = commitLogReaderService.createTask("filename", 1, 1, true);
+
+        // when
+        commitLogReaderService.addPendingTask(task);
+
+        // then
+        boolean allRetriesCompleted = commitLogReaderService.getRetrylatch().await(10, TimeUnit.SECONDS); // wait for the task to be executed and retied
+        assertTrue(allRetriesCompleted, "all retries should've been completed");
+        executorService.shutdown();
+        boolean terminated = executorService.awaitTermination(10, TimeUnit.SECONDS); // if semaphore permits where not released, awaitTermination will timeout
+        assertTrue(terminated, "executor service should've been terminated");
+        assertTrue(commitLogReaderService.getPendingTasks().isEmpty(), "pending tasks should be empty");
+        assertEquals(3, commitLogReaderService.getAvailablePermitsRecorder().size());
+        int recordPermitsCount = 0;
+        while (!commitLogReaderService.getAvailablePermitsRecorder().isEmpty()) {
+            recordPermitsCount++;
+            int permits = commitLogReaderService.getAvailablePermitsRecorder().poll();
+            if (recordPermitsCount == 3) { // this is the last recorded permit, should be 0
+                assertEquals(0, permits);
+            } else {
+                assertEquals(config.maxInflightMessagesPerTask, permits);
+            }
+        }
+    }
+
+    class MyCommitLogService extends CommitLogReaderService {
+        public MyCommitLogService(AgentConfig config, MutationSender<?> mutationSender, SegmentOffsetWriter segmentOffsetWriter, CommitLogTransfer commitLogTransfer, ExecutorService executorService) {
+            super(config, mutationSender, segmentOffsetWriter, commitLogTransfer);
+            this.tasksExecutor = executorService;
+
+        }
+
+        File mockFile = Mockito.mock(File.class);
+        CountDownLatch retryLatch = new CountDownLatch(3); // fail twice, succeed on third retry
+        BlockingQueue<Integer> availablePermitsRecorder = new LinkedBlockingDeque<>();
+
+        @Override
+        public Task createTask(String commitlogName, long seg, int pos, boolean completed) {
+            return new CommitLogReaderService.Task("filename", 1, 1, true) {
+                public void run() {
+                    // this is where the code will block if the permits are not released properly. The idea
+                    // is to limit the number of inflight messages per task, but it is up to the implementation to
+                    // adhere to that.
+                    inflightMessagesSemaphore.acquireUninterruptibly();
+                    try {
+                        if (retryLatch.getCount() > 1) {
+                            lastException = new RuntimeException("failed to send to pulsar");
+                        } else {
+                            lastException = null;
+                        }
+                        Thread.sleep(50L); // noop, could be any rpc call in reality
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    inflightMessagesSemaphore.release();
+                    super.finish(TaskStatus.SUCCESS, -1);
+                    availablePermitsRecorder.add(inflightMessagesSemaphore.availablePermits());
+                    retryLatch.countDown();
+                }
+
+                @Override
+                public File getFile() {
+                    return mockFile;
+                }
+            };
+        }
+
+        public CountDownLatch getRetrylatch() {
+            return retryLatch;
+        }
+
+        public ConcurrentMap<Long, Task> getPendingTasks() {
+            return pendingTasks;
+        }
+
+        public BlockingQueue<Integer> getAvailablePermitsRecorder() {
+            return availablePermitsRecorder;
+        }
+    }
+}


### PR DESCRIPTION
This patch solves a problem on the agent when pulsar is temporarily unavailable and then recovers, task with partial failures could hand forever. Here is a sample timeline: 
**[T1]** Pulsar endpoint is not reachable due to a network problem
**[T2]** A CDC enabled table continues to receive mutations. All mutations are sent to the `cdc_raw` for async processing
**[T3]** Agent picks up the `*.idx` files form the `cdc_raw` and submits to the `pendingTasks` queue for execution. Although there is logical 1:1 mapping between a `Task` and a `segment` (represented by a pair of `*.idx` and `*.log` files in the commit log dir, the segment file is mutable. With each segment mutation, a new task is submitted for processing.   
**[T4]** Task starts, it will read the log files and starts sending mutations one by one, up to available permits in the `inflightMessagesSemaphore`
**[T5]** Because pulsar is not available, each task will wait forever until pulsar is back, there is controlled by the [finish()](https://github.com/datastax/cdc-apache-cassandra/blob/66482c848f16f29ee31a33c58fced25a56785e02/agent/src/main/java/com/datastax/oss/cdc/agent/CommitLogReaderService.java#L271) logic
**[T6]** pulsar  becomes reachable again
**[T7]** there are two possibilities depending on what happen in the inflight pulsar requests:
 * If all of them finish successfully,  the finish() logic will unblock and the task is complete. This can happen because the pulsar client is configured to run forever - no issues here.
 * If there are partial failures (i.e. because of `org.apache.pulsar.client.api.PulsarClientException$AuthenticationException: Failed to authenticate` like the ones observed in dev and `PulsarClientException: java.util.concurrent.CompletionException: java.net.UnknownHostException` like the one observed in prod, that task will partially fail, and attempt to resubmit it self here: https://github.com/datastax/cdc-apache-cassandra/blob/7912d85c2be16c7ba9560109b95404e71e13a83d/agent/src/main/java/com/datastax/oss/cdc/agent/CommitLogReaderService.java#L283
There are again two possibilities here: 
 * * If there are other pending tasks already wait (because of the mutable nature of `*.idx` files mentioned above), then the current task instance will not be resubmitted as the other pending task will do. This is a lucky case that will cause no issue, but it will actually mask the next issue
   * If there are no other pending tasks, because the current task instance is the last one, then the task will resubmit itself **without releasing the permits** - this will goes that current task thread to wait forever on this line as it tries to return to business as usual (remember, pulsar is back online now and some progress should be made): https://github.com/datastax/cdc-apache-cassandra/blob/39b48d77ecd127baba97a3c4453c06ca6577c1b5/agent-dse4/src/main/java/com/datastax/oss/cdc/agent/CommitLogReaderServiceImpl.java#L90
   
   
A thread dump was taken that is inline with the above findings, here is the interesting part:
![Thread dump](https://user-images.githubusercontent.com/13960949/236987630-b6028831-0208-435c-98f8-149376657872.png)

A unit test is added to mimic what happened during the thread dump as close as possible
     
 Fill thread dump: https://jstack.review/?https://gist.github.com/aymkhalil/237de69bb919d13413df30c77570fd93