### PR TITLE
Log agent version on startup

### DIFF
--- a/agent-dse4/build.gradle
+++ b/agent-dse4/build.gradle
@@ -15,6 +15,7 @@ jar {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
     manifest {
         attributes 'Premain-Class': "$mainClassName"
+        attributes 'Implementation-Version': project.version
     }
     zip64=true
 }

--- a/agent-dse4/src/main/java/com/datastax/oss/cdc/agent/Agent.java
+++ b/agent-dse4/src/main/java/com/datastax/oss/cdc/agent/Agent.java
@@ -57,7 +57,8 @@ public class Agent {
     }
 
     static void startCdcAgent(String agentArgs) throws Exception {
-        log.info("Starting CDC agent, cdc_raw_directory={}", DatabaseDescriptor.getCDCLogLocation());
+        String agentVersion = Agent.class.getPackage().getImplementationVersion();
+        log.info("Starting CDC agent v{}, cdc_raw_directory={}", agentVersion, DatabaseDescriptor.getCDCLogLocation());
         AgentConfig config = AgentConfig.create(AgentConfig.Platform.PULSAR, agentArgs);
 
         SegmentOffsetFileWriter segmentOffsetFileWriter = new SegmentOffsetFileWriter(config.cdcWorkingDir);


### PR DESCRIPTION
Add agent version to the log upon start for troubleshooting. Check `Implementation-Version` on https://docs.oracle.com/javase/tutorial/deployment/jar/packageman.html

Tested locally:
```
INFO  [main] 2023-05-10 14:54:40,672  Agent.java:61 - Starting CDC agent v2.2.8, cdc_raw_directory=/private/var/lib/cassandra/cdc_raw
```