### PR TITLE
DOC-3853: Update/add support_url attribute

### DIFF
--- a/docs/playbooks/site-local-cdc-cassandra.yaml
+++ b/docs/playbooks/site-local-cdc-cassandra.yaml
@@ -36,7 +36,7 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
 
-    support_url: 'https://houston.datastax.com/hc/requests/new'
+    support_url: 'https://support.datastax.com'
     astra_docs_base_url: 'https://docs.datastax.com/en/astra/docs'
 
     # The "glossary-url" attribute below is used by writers when linking to a

--- a/docs/playbooks/site-publish-cdc-cassandra.yaml
+++ b/docs/playbooks/site-publish-cdc-cassandra.yaml
@@ -39,7 +39,9 @@ asciidoc:
     sectlinks: ''
     idprefix: ''
     idseparator: '-'
-    source-highlighter: highlightjs
+
+    support_url: 'https://support.datastax.com'
+    astra_docs_base_url: 'https://docs.datastax.com/en/astra/docs'
 
     # The "glossary-url" attribute below is used by writers when linking to a
     # term in the glossary. Referencing this attribute in an adoc file will


### PR DESCRIPTION
**JIRA:** https://datastax.jira.com/browse/DOC-3853

This change updates/adds the `support_url` attribute with the correct link to the DataStax Support website.