### PR TITLE
version-resolve

### DIFF
--- a/docs/docs-src/core/antora-cdc-cassandra.yml
+++ b/docs/docs-src/core/antora-cdc-cassandra.yml
@@ -11,6 +11,6 @@ asciidoc:
     cdc_pulsar: 'CDC for Cassandra'
     luna_version: '2.10'
     pulsar_version: '2.10'
-    version: '2.2.9' # resolve cdc-apache-cassandra <latest> version with {version} in samples
+    version: '2.2.9' # cdc-apache-cassandra latest {version}
 nav:
 - modules/ROOT/nav.adoc

--- a/docs/docs-src/core/antora-cdc-cassandra.yml
+++ b/docs/docs-src/core/antora-cdc-cassandra.yml
@@ -11,5 +11,6 @@ asciidoc:
     cdc_pulsar: 'CDC for Cassandra'
     luna_version: '2.10'
     pulsar_version: '2.10'
+    version: '2.2.9' # resolve cdc-apache-cassandra <latest> version with {version} in samples
 nav:
 - modules/ROOT/nav.adoc

--- a/docs/docs-src/core/modules/ROOT/examples/java-start.sh
+++ b/docs/docs-src/core/modules/ROOT/examples/java-start.sh
@@ -1,2 +1,2 @@
-java -jar backfill-cli/build/libs/backfill-cli-<version>-all.jar --data-dir target/export --export-host 127.0.0.1:9042 \
+java -jar backfill-cli/build/libs/backfill-cli-{version}-all.jar --data-dir target/export --export-host 127.0.0.1:9042 \
  --export-username cassandra --export-password cassandra --keyspace ks1 --table table1

--- a/docs/docs-src/core/modules/ROOT/pages/backfill-cli.adoc
+++ b/docs/docs-src/core/modules/ROOT/pages/backfill-cli.adoc
@@ -41,8 +41,8 @@ BUILD SUCCESSFUL in 37s
 
 Gradle generates two main artifacts:
 
-* An uber JAR file containing the CLI and all its dependencies: backfill-cli/build/libs/backfill-cli-<version>-all.jar
-* A NAR archive that wraps the CLI as a Pulsar-admin Extension: backfill-cli/build/libs/pulsar-cassandra-admin-<version>-nar.nar
+* An uber JAR file containing the CLI and all its dependencies: backfill-cli/build/libs/backfill-cli-{version}-all.jar
+* A NAR archive that wraps the CLI as a Pulsar-admin Extension: backfill-cli/build/libs/pulsar-cassandra-admin-{version}-nar.nar
 
 Once the artifacts are generated, you can run the backfill CLI tool as either a standalone Java application or as a Pulsar-admin extension.
 [tabs]


### PR DESCRIPTION
Add a `version` asciidoc attribute to reference the current cdc release version in docs.
Reference it with `{version}`.
Note that you will need to include the `,subs="attributes+"` to render the variable in code sample blocks, as below.
```
Java standalone::
+
--
[source,shell,subs="attributes+"]
----
include::example$java-start.sh[]
----
--
```
Coppi build: https://coppi.aws.dsinternal.org/en/latest-version-var/docs/2.2.9/backfill-cli.html

