### PR TITLE
Upgrade pulsar client to 3.0.0

### DIFF
--- a/backfill-cli/gradle.properties
+++ b/backfill-cli/gradle.properties
@@ -1,4 +1,2 @@
 artifact=backfill-cli
 mainClassName=com.datastax.oss.cdc.backfill.BackfillCLI
-
-pulsarVersion=2.11.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ cassandra4Version=4.0.4
 dse4Version=6.8.23
 
 pulsarGroup=org.apache.pulsar
-pulsarVersion=2.10.4
+pulsarVersion=3.0.0
 # Used when running tests locally, CI will override those values
 testPulsarImage=datastax/lunastreaming
 testPulsarImageTag=2.10_3.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ cassandra4Version=4.0.4
 dse4Version=6.8.23
 
 pulsarGroup=org.apache.pulsar
-pulsarVersion=2.10.3
+pulsarVersion=2.10.4
 # Used when running tests locally, CI will override those values
 testPulsarImage=datastax/lunastreaming
 testPulsarImageTag=2.10_3.4


### PR DESCRIPTION
At the time https://github.com/datastax/cdc-apache-cassandra/pull/144 was implemented, pulsar client 2.10.4 was not released. This patch is a follow up to use the recommended version. Please note that 2.11 is not possible to use atm because it required java 17 CDC need to compile with java 11,