### PR TITLE
deps: Update versions for fixes 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ snapshotsRepoUrl=https://repo.aws.dsinternal.org/artifactory/datastax-snapshots-
 releasesRepoUrl=https://repo.datastax.com/artifactory/datastax-public-releases-local
 
 # deps version
-avroVersion=1.10.2
+avroVersion=1.11.3
 lombokVersion=1.18.20
 ossDriverVersion=4.16.0
 cassandra3Version=3.11.10
@@ -24,18 +24,18 @@ kafkaVersion=3.4.0
 vavrVersion=0.10.3
 testContainersVersion=1.16.2
 caffeineVersion=2.8.8
-guavaVersion=30.1-jre
+guavaVersion=32.0.1-jre
 messagingConnectorsCommonsVersion=1.0.14
 slf4jVersion=1.7.30
 # pulsar connector
-logbackVersion=1.2.9
+logbackVersion=1.2.13
 jacksonBomVersion=2.13.4.20221013
 jnrVersion=3.1.15
 nettyVersion=4.1.72.Final
 nettyTcNativeVersion=2.0.46.Final
 commonCompressVersion=1.21
 gsonVersion=2.8.9
-jsonVersion=20230227
+jsonVersion=20231013
 
 # cassandra settings for docker images
 commitlog_sync_period_in_ms=2000


### PR DESCRIPTION
### Motivation
To Avoid the following Vulnerabilities 

- JSON : CVE-2023-5072
- Logback-core & Logback-classic : CVE-2023-6378
- Avro : CVE-2023-39410
- Guava : CVE-2023-2976, CVE-2020-8908

### Modifications
Upgraded Following versions - 

- json : 20230227 -> 20231013
- logback-core : 1.2.9 -> 1.2.13
- logback-classic : 1.2.9 -> 1.2.13
- avro : 1.10.2 -> 1.11.3
- guava : 30.1-jre -> 32.0.1-jre

### Verifying this change

- [X] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [X] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)