### PR TITLE
Upgrade Avro to 1.11.4 to address CVE-2024-47561

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ snapshotsRepoUrl=https://repo.aws.dsinternal.org/artifactory/datastax-snapshots-
 releasesRepoUrl=https://repo.datastax.com/artifactory/datastax-public-releases-local
 
 # deps version
-avroVersion=1.10.2
+avroVersion=1.11.4
 lombokVersion=1.18.20
 ossDriverVersion=4.16.0
 cassandra3Version=3.11.10


### PR DESCRIPTION
# Motivation

Avro 1.11.3 contains critical 9.3/10 level RCE vulnerability in Avro Java SDK <1.11.4, [CVE-2024-47561](https://github.com/advisories/GHSA-r7pg-v2c8-mfg3)>