### PR TITLE
fix: add org.ajoberstar.grgit plugin to build.gradle to resolve dependency issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'application'
     id "com.dorongold.task-tree" version "2.1.0"
     id "jacoco"
+    id 'org.ajoberstar.grgit' version '4.1.1'
     id "com.gorylenko.gradle-git-properties" version "2.3.1"
     id "com.google.osdetector" version "1.7.0"
     id "kr.motd.sphinx" version "2.10.1"
@@ -45,6 +46,7 @@ allprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'com.google.osdetector'
     apply plugin: 'com.github.hierynomus.license'
+    apply plugin: 'org.ajoberstar.grgit'
     apply plugin: 'com.gorylenko.gradle-git-properties'
     apply plugin: 'com.github.jk1.dependency-license-report'
 


### PR DESCRIPTION
Added the org.ajoberstar.grgit plugin to build.gradle to resolve dependency issues with com.gorylenko.gradle-git-properties. This ensures that the required grgit-core dependency can be correctly fetched during the Gradle build process.
