### PR TITLE
chore(deps): multiple dependencies update

### DIFF
--- a/commons/src/main/java/com/datastax/oss/cdc/NativeSchemaWrapper.java
+++ b/commons/src/main/java/com/datastax/oss/cdc/NativeSchemaWrapper.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.cdc;
 
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaFormatter;
 import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -35,7 +36,7 @@ public class NativeSchemaWrapper implements org.apache.pulsar.client.api.Schema<
         this.nativeSchema = nativeSchema;
         this.pulsarSchemaType = pulsarSchemaType;
         this.pulsarSchemaInfo = SchemaInfo.builder()
-                .schema(nativeSchema.toString(false).getBytes(StandardCharsets.UTF_8))
+                .schema(SchemaFormatter.getInstance("json").format(nativeSchema).getBytes(StandardCharsets.UTF_8))
                 .properties(new HashMap<>())
                 .type(pulsarSchemaType)
                 .name(nativeSchema.getName())

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,35 +7,35 @@ snapshotsRepoUrl=https://repo.aws.dsinternal.org/artifactory/datastax-snapshots-
 releasesRepoUrl=https://repo.datastax.com/artifactory/datastax-public-releases-local
 
 # deps version
-avroVersion=1.11.4
-lombokVersion=1.18.20
-ossDriverVersion=4.16.0
-cassandra3Version=3.11.10
-cassandra4Version=4.0.4
+avroVersion=1.12.0
+lombokVersion=1.18.38
+ossDriverVersion=4.17.0
+cassandra3Version=3.11.19
+cassandra4Version=4.0.18
 dse4Version=6.8.23
 
 pulsarGroup=org.apache.pulsar
-pulsarVersion=3.0.0
+pulsarVersion=3.0.12
 # Used when running tests locally, CI will override those values
 testPulsarImage=datastax/lunastreaming
 testPulsarImageTag=2.10_3.4
 
-kafkaVersion=3.4.0
-vavrVersion=0.10.3
-testContainersVersion=1.19.1
-caffeineVersion=2.8.8
+kafkaVersion=3.4.1
+vavrVersion=0.10.6
+testContainersVersion=1.19.8
+caffeineVersion=2.9.3
 guavaVersion=30.1-jre
-messagingConnectorsCommonsVersion=1.0.14
-slf4jVersion=1.7.30
+messagingConnectorsCommonsVersion=1.0.15
+slf4jVersion=1.7.36
 # pulsar connector
-logbackVersion=1.2.9
-jacksonBomVersion=2.13.4.20221013
-jnrVersion=3.1.15
-nettyVersion=4.1.72.Final
-nettyTcNativeVersion=2.0.46.Final
-commonCompressVersion=1.21
+logbackVersion=1.2.23
+jacksonBomVersion=2.13.5
+jnrVersion=3.1.20
+nettyVersion=4.1.122.Final
+nettyTcNativeVersion=4.1.122.Final
+commonCompressVersion=1.27.1
 gsonVersion=2.8.9
-jsonVersion=20230227
+jsonVersion=20250107
 
 # cassandra settings for docker images
 commitlog_sync_period_in_ms=2000

--- a/testcontainers/src/main/java/com/datastax/oss/cdc/PulsarDualNodeTests.java
+++ b/testcontainers/src/main/java/com/datastax/oss/cdc/PulsarDualNodeTests.java
@@ -19,13 +19,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.testcontainers.PulsarContainer;
 import com.datastax.testcontainers.cassandra.CassandraContainer;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionInitialPosition;
-import org.apache.pulsar.client.api.SubscriptionMode;
-import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
 import org.apache.pulsar.client.api.schema.SchemaBuilder;
@@ -39,14 +33,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.Network;
+import org.testcontainers.images.builder.Transferable;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -229,10 +220,12 @@ public abstract class PulsarDualNodeTests {
         String pulsarServiceUrl = "pulsar://pulsar:" + pulsarContainer.BROKER_PORT;
         Long testId = Math.abs(AgentTestUtil.random.nextLong());
         String randomDataDir = System.getProperty("buildDir") + "/data-" + testId + "-";
-        try (CassandraContainer<?> cassandraContainer1 = createCassandraContainer(1, pulsarServiceUrl, testNetwork)
-                .withFileSystemBind(randomDataDir + "1", "/var/lib/cassandra");
-             CassandraContainer<?> cassandraContainer2 = createCassandraContainer(2, pulsarServiceUrl, testNetwork)
-                     .withFileSystemBind(randomDataDir + "2", "/var/lib/cassandra")) {
+        try (
+                CassandraContainer<?> cassandraContainer1 = createCassandraContainer(1, pulsarServiceUrl, testNetwork)
+                .withCopyToContainer(Transferable.of(randomDataDir + "1"), "/var/lib/cassandra");
+                CassandraContainer<?> cassandraContainer2 = createCassandraContainer(2, pulsarServiceUrl, testNetwork)
+                     .withCopyToContainer(Transferable.of(randomDataDir + "2"), "/var/lib/cassandra")
+        ) {
             cassandraContainer1.start();
             cassandraContainer2.start();
 

--- a/testcontainers/src/main/java/com/datastax/testcontainers/ChaosNetworkContainer.java
+++ b/testcontainers/src/main/java/com/datastax/testcontainers/ChaosNetworkContainer.java
@@ -35,7 +35,7 @@ public class ChaosNetworkContainer<SELF extends ChaosNetworkContainer<SELF>> ext
     public ChaosNetworkContainer(String targetContainer, String pause) {
         super(PUMBA_IMAGE);
         setCommand("--log-level debug netem --tc-image gaiadocker/iproute2 --duration " + pause + " loss --percent 100 " + targetContainer);
-        addFileSystemBind("/var/run/docker.sock", "/var/run/docker.sock", BindMode.READ_WRITE);
+        withFileSystemBind("/var/run/docker.sock", "/var/run/docker.sock", BindMode.READ_WRITE);
         setWaitStrategy(Wait.forLogMessage(".*tc container created.*", 1));
         withLogConsumer(o -> {
             final String line = o.getUtf8String();

--- a/testcontainers/src/main/java/com/datastax/testcontainers/cassandra/CassandraContainer.java
+++ b/testcontainers/src/main/java/com/datastax/testcontainers/cassandra/CassandraContainer.java
@@ -30,6 +30,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.delegate.DatabaseDelegate;
 import org.testcontainers.ext.ScriptUtils;
 import org.testcontainers.ext.ScriptUtils.ScriptLoadException;
+import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
@@ -288,8 +289,8 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
                 .withCreateContainerCmdModifier(c -> c.withName("cassandra-" + nodeIndex))
                 .withNetwork(network)
                 .withConfigurationOverride(configLocation)
-                .withFileSystemBind(
-                        String.format(Locale.ROOT, "%s/libs/%s", agentBuildDir, jarFile),
+                .withCopyToContainer(
+                        Transferable.of(String.format(Locale.ROOT, "%s/libs/%s", agentBuildDir, jarFile)),
                         String.format(Locale.ROOT, "/%s", jarFile))
                 .withEnv("JVM_EXTRA_OPTS", String.format(Locale.ROOT,
                         "-javaagent:/%s=%s -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" +


### PR DESCRIPTION
fixes #137 

Dependency updated:

1. avroVersion - 1.11.4 -> 1.12.0
2. lombokVersion- 1.18.20 -> 1.18.38
3. ossDriverVersion- 4.16.0 -> 4.17.0
4. cassandra3Version- 3.11.10 -> 3.11.19
5. cassandra4Version- 4.0.4 -> 4.0.18
6. pulsarVersion - 3.0.0 -> 3.0.12
7.  kafkaVersion- 3.4.1 -> 3.4.1
8. vavrVersion- 0.10.3 -> 0.10.6
9. testContainersVersion - 1.19.1 -> 1.19.8
10. caffeineVersion- 2.8.8 -> 2.9.3
11. messagingConnectorsCommonsVersion - 1.0.14 -> 1.0.15
12. slf4jVersion - 1.7.30 -> 1.7.36
13. logbackVersion - 1.2.9 -> 1.2.23
14. jacksonBomVersion - 2.13.4.20221013 -> 2.13.5
15. jnrVersion - 3.1.15 -> 3.1.20
16. nettyVersion - 4.1.72.Final -> 4.1.122.Final
17. nettyTcNativeVersion - 2.0.46.Final -> 4.1.122.Final
18. commonCompressVersion - 1.21 -> 1.27.1
19. jsonVersion - 20230227 -> 20250107