### PR TITLE
Persistent Cache Implementation using RocksDB

### DIFF
--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -32,6 +32,7 @@ sourceSets {
 dependencies {
     implementation project(':commons')
     implementation("com.github.ben-manes.caffeine:caffeine:${caffeineVersion}")
+    implementation("org.rocksdb:rocksdbjni:${rocksdbVersion}")
     implementation("io.vavr:vavr:${vavrVersion}")
     implementation "com.datastax.oss:java-driver-core:${ossDriverVersion}"
     implementation "com.datastax.oss:java-driver-query-builder:${ossDriverVersion}"

--- a/connector/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
@@ -66,6 +66,8 @@ public class CassandraSourceConnectorConfig {
     public static final String CACHE_MAX_DIGESTS_CONFIG = "cache.max.digest";
     public static final String CACHE_MAX_CAPACITY_CONFIG = "cache.max.capacity";
     public static final String CACHE_EXPIRE_AFTER_MS_CONFIG = "cache.expire.after.ms";
+    public static final String CACHE_PERSISTENT_DIRECTORY_CONFIG = "cache.persistent.directory";
+
 
     public static final String KEY_CONVERTER_CLASS_CONFIG = "key.converter";
     public static final String VALUE_CONVERTER_CLASS_CONFIG = "value.converter";
@@ -195,6 +197,13 @@ public class CassandraSourceConnectorConfig {
                             ConfigDef.Importance.HIGH,
                             "The maximum number of digest per mutation cache entry, with a default set to 3",
                             "CQL Read cache", 1, ConfigDef.Width.NONE, "CacheMaxDigest")
+                    .define(CACHE_PERSISTENT_DIRECTORY_CONFIG,
+                            ConfigDef.Type.STRING,
+                            null,
+                            ConfigDef.Importance.HIGH,
+                            "The directory where the persistent mutation cache will be stored. Formated as `{cache.persistent.directory}/{source-name}-{instance-id}` " +
+                                    "If set, the connector will use RocksDB to store digests, otherwise it will use an in-memory cache.",
+                            "CQL Read cache", 1, ConfigDef.Width.NONE, "CachePersistentDirectory")
                     .define(CACHE_MAX_CAPACITY_CONFIG,
                             ConfigDef.Type.LONG,
                             "32767",
@@ -661,6 +670,10 @@ public class CassandraSourceConnectorConfig {
         return globalConfig.getLong(CACHE_MAX_DIGESTS_CONFIG);
     }
 
+    public String getCachePersistentDirectory() {
+        return globalConfig.getString(CACHE_PERSISTENT_DIRECTORY_CONFIG);
+    }
+
     public long getCacheMaxCapacity() {
         return globalConfig.getLong(CACHE_MAX_CAPACITY_CONFIG);
     }
@@ -782,6 +795,7 @@ public class CassandraSourceConnectorConfig {
                         + "        " + QUERY_BACKOFF_IN_MS_CONFIG + ": %d%n"
                         + "        " + QUERY_MAX_BACKOFF_IN_SEC_CONFIG + ": %d%n"
                         + "        " + CACHE_MAX_DIGESTS_CONFIG + ": %d%n"
+                        + "        " + CACHE_PERSISTENT_DIRECTORY_CONFIG + ": %s%n"
                         + "        " + CACHE_MAX_CAPACITY_CONFIG + ": %d%n"
                         + "        " + CACHE_EXPIRE_AFTER_MS_CONFIG + ": %d%n"
                         + "        " + CACHE_ONLY_IF_COORDINATOR_MATCH + ": %s%n"
@@ -805,6 +819,7 @@ public class CassandraSourceConnectorConfig {
                 getQueryBackoffInMs(),
                 getQueryMaxBackoffInSec(),
                 getCacheMaxDigests(),
+                getCachePersistentDirectory(),
                 getCacheMaxCapacity(),
                 getCacheExpireAfterMs(),
                 getCacheOnlyIfCoordinatorMatch(),

--- a/connector/src/main/java/com/datastax/oss/cdc/cache/InMemoryCache.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/cache/InMemoryCache.java
@@ -1,19 +1,4 @@
-/**
- * Copyright DataStax, Inc 2021.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package com.datastax.oss.cdc;
+package com.datastax.oss.cdc.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -24,19 +9,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Keep MD5 digests to deduplicate Cassandra mutations
- */
-public class MutationCache<K> {
-
+public class InMemoryCache<K> implements MutationCache<K> {
     Cache<K, List<String>> mutationCache;
 
     /**
-     * Max number of cached digest per cached entry.
+     * Max number of cached digests per cached entry.
      */
     long maxDigests;
 
-    public MutationCache(long maxDigests, long maxCapacity, Duration expireAfter) {
+    public InMemoryCache(long maxDigests, long maxCapacity, Duration expireAfter) {
         this.maxDigests = maxDigests;
         mutationCache = Caffeine.newBuilder()
                 .expireAfterWrite(expireAfter.getSeconds(), TimeUnit.SECONDS)

--- a/connector/src/main/java/com/datastax/oss/cdc/cache/InMemoryCache.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/cache/InMemoryCache.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.cdc.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;

--- a/connector/src/main/java/com/datastax/oss/cdc/cache/MutationCache.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/cache/MutationCache.java
@@ -1,0 +1,41 @@
+package com.datastax.oss.cdc.cache;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+
+import java.util.List;
+
+public interface MutationCache<K> {
+    /**
+     * Add a mutation MD5 digest to the cache for the given mutation key.
+     * @param mutationKey the key for the mutation, typically a partition key or a unique identifier
+     * @param md5Digest the MD5 digest of the mutation to be added
+     * @return a list of MD5 digests for the given mutation key, which may include the newly added digest
+     */
+    List<String> addMutationMd5(K mutationKey, String md5Digest);
+
+    /**
+     * Retrieve the list of MD5 digests for the given mutation key.
+     * @param mutationKey the key for the mutation
+     * @return a list of MD5 digests associated with the mutation key, or an empty list if none exist
+     */
+    List<String> getMutationCRCs(K mutationKey);
+
+    /**
+     * Check if a mutation with the given key and MD5 digest has already been processed.
+     * @param mutationKey the key for the mutation
+     * @param md5Digest the MD5 digest of the mutation
+     * @return true if the mutation has been processed, false otherwise
+     */
+    boolean isMutationProcessed(K mutationKey, String md5Digest);
+
+    /**
+     * Gives the current statistics of the cache, such as hit rate, miss rate, and size.
+     * <a href="https://github.com/ben-manes/caffeine/wiki/Statistics">Caffeine Statistics wiki</a>
+     */
+    CacheStats stats();
+
+    /**
+     * Gives the estimated size of the cache.
+     */
+    long estimatedSize();
+}

--- a/connector/src/main/java/com/datastax/oss/cdc/cache/MutationCache.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/cache/MutationCache.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.cdc.cache;
 
 import com.github.benmanes.caffeine.cache.stats.CacheStats;

--- a/connector/src/main/java/com/datastax/oss/cdc/cache/PersistentCache.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/cache/PersistentCache.java
@@ -1,10 +1,24 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.cdc.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
-import com.google.common.annotations.VisibleForTesting;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.TtlDB;

--- a/connector/src/main/java/com/datastax/oss/cdc/cache/PersistentCache.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/cache/PersistentCache.java
@@ -1,0 +1,124 @@
+package com.datastax.oss.cdc.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.TtlDB;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+public class PersistentCache<K> implements MutationCache<K> {
+    /**
+     * The mutation cache
+     */
+    Cache<K, List<String>> mutationCache;
+
+    private final TtlDB rocksDB;
+    /**
+     * Max number of cached digests per cached entry.
+     */
+    long maxDigests;
+
+    private final Function<K, byte[]> keySerializer;
+
+    static {
+        TtlDB.loadLibrary();
+    }
+
+    public PersistentCache(long maxDigests, long maxCapacity, Duration expireAfter, String dbPath, Function<K, byte[]> keySerializer) throws RocksDBException {
+        this.maxDigests = maxDigests;
+        this.keySerializer = keySerializer;
+
+        Options options = new Options().setCreateIfMissing(true);
+        this.rocksDB = TtlDB.open(options, dbPath, (int) expireAfter.getSeconds(), false);
+
+        this.mutationCache = Caffeine.newBuilder()
+                .expireAfterWrite(expireAfter.getSeconds(), TimeUnit.SECONDS)
+                .maximumSize(maxCapacity)
+                .executor(Runnable::run)
+                .recordStats()
+                .removalListener((K key, List<String> value, RemovalCause cause) -> {
+                    try {
+                        rocksDB.delete(this.keySerializer.apply(key));
+                    } catch (RocksDBException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .build();
+    }
+
+
+    private List<String> valueDeserializer(byte[] data){
+        return data == null || data.length == 0 ? null : List.of(new String(data).split(","));
+    }
+
+    private byte[] valueSerializer(List<String> data){
+        return data.stream()
+                .reduce((s1, s2) -> s1 + "," + s2)
+                .orElse("")
+                .getBytes();
+    }
+
+    public List<String> getMutationCRCs(K mutationKey) {
+        return mutationCache.get(mutationKey, k -> {
+            try {
+                return valueDeserializer(rocksDB.get(this.keySerializer.apply(k)));
+            } catch (RocksDBException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public void putMutationCRCs(K key, List<String> value) {
+        mutationCache.asMap().compute(key, (k, v) -> {
+            try {
+                rocksDB.put(keySerializer.apply(k), valueSerializer(value));
+            } catch (RocksDBException e) {
+                throw new RuntimeException(e);
+            }
+            return value;
+        });
+    }
+
+    public List<String> addMutationMd5(K mutationKey, String md5Digest) {
+        List<String> crcs = getMutationCRCs(mutationKey);
+        if(crcs == null) {
+            crcs = new ArrayList<>(1);
+            crcs.add(md5Digest);
+        } else {
+            if (!crcs.contains(md5Digest)) {
+                if (crcs.size() >= maxDigests) {
+                    // remove the oldest digest
+                    crcs.remove(0);
+                }
+                crcs.add(md5Digest);
+            }
+        }
+        putMutationCRCs(mutationKey, crcs);
+        return crcs;
+    }
+
+    public boolean isMutationProcessed(K mutationKey, String md5Digest) {
+        List<String> digests = getMutationCRCs(mutationKey);
+        return digests != null && digests.contains(md5Digest);
+    }
+
+    public CacheStats stats() {
+        return mutationCache.stats();
+    }
+
+    public long estimatedSize() {
+        return mutationCache.estimatedSize();
+    }
+
+    public void close() {
+        rocksDB.close();
+    }
+}

--- a/connector/src/test/java/com/datastax/oss/cdc/MutationCacheTests.java
+++ b/connector/src/test/java/com/datastax/oss/cdc/MutationCacheTests.java
@@ -15,17 +15,22 @@
  */
 package com.datastax.oss.cdc;
 
+import com.datastax.oss.cdc.cache.InMemoryCache;
+import com.datastax.oss.cdc.cache.MutationCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MutationCacheTests {
 
     @Test
     public final void testMaxDigests() throws Exception {
-        MutationCache mutationCache = new MutationCache(3, 10, Duration.ofHours(1));
+        MutationCache<String> mutationCache = new InMemoryCache<>(3, 10, Duration.ofHours(1));
         mutationCache.addMutationMd5("mutation1","digest1");
         mutationCache.addMutationMd5("mutation1","digest2");
         mutationCache.addMutationMd5("mutation1","digest3");
@@ -35,20 +40,20 @@ public class MutationCacheTests {
 
     @Test
     public final void testIsProcessed() throws Exception {
-        MutationCache mutationCache = new MutationCache(3, 10, Duration.ofHours(1));
-        assertEquals(false,mutationCache.isMutationProcessed("mutation1","digest1"));
+        MutationCache<String> mutationCache = new InMemoryCache<>(3, 10, Duration.ofHours(1));
+        assertFalse(mutationCache.isMutationProcessed("mutation1", "digest1"));
         mutationCache.addMutationMd5("mutation1","digest1");
-        assertEquals(true, mutationCache.isMutationProcessed("mutation1","digest1"));
+        assertTrue(mutationCache.isMutationProcessed("mutation1", "digest1"));
     }
 
     @Test
     public final void testExpireAfter() throws Exception {
-        MutationCache mutationCache = new MutationCache(3, 10, Duration.ofSeconds(1));
-        assertEquals(false, mutationCache.isMutationProcessed("mutation1","digest1"));
+        MutationCache<String> mutationCache = new InMemoryCache<>(3, 10, Duration.ofSeconds(1));
+        assertFalse(mutationCache.isMutationProcessed("mutation1", "digest1"));
         mutationCache.addMutationMd5("mutation1","digest1");
-        assertEquals(true, mutationCache.isMutationProcessed("mutation1","digest1"));
+        assertTrue(mutationCache.isMutationProcessed("mutation1", "digest1"));
         Thread.sleep(2000);
-        assertEquals(false, mutationCache.isMutationProcessed("mutation1","digest1"));
+        assertFalse(mutationCache.isMutationProcessed("mutation1", "digest1"));
     }
 
 }

--- a/connector/src/test/java/com/datastax/oss/cdc/cache/MutationCacheTests.java
+++ b/connector/src/test/java/com/datastax/oss/cdc/cache/MutationCacheTests.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.cdc;
+package com.datastax.oss.cdc.cache;
 
-import com.datastax.oss.cdc.cache.InMemoryCache;
-import com.datastax.oss.cdc.cache.MutationCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.junit.jupiter.api.Test;
 

--- a/connector/src/test/java/com/datastax/oss/cdc/cache/PersistentCacheTests.java
+++ b/connector/src/test/java/com/datastax/oss/cdc/cache/PersistentCacheTests.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.cdc.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.google.common.testing.FakeTicker;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.rocksdb.RocksDBException;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PersistentCacheTests {
+    private String path;
+
+    @BeforeEach
+    public void setUp() {
+        path = "./rocksdb_mutation_cache_" + (new Random()).nextInt();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        try {
+            FileUtils.deleteDirectory(new File(path));
+        } catch (Exception e) {
+            // Ignore any exceptions during cleanup
+        }
+    }
+
+    @Test
+    public final void testMaxDigests() throws Exception {
+        MutationCache<String> mutationCache = new PersistentCache<>(3, 10, Duration.ofHours(1), path, String::getBytes);
+        mutationCache.addMutationMd5("mutation1","digest1");
+        mutationCache.addMutationMd5("mutation1","digest2");
+        mutationCache.addMutationMd5("mutation1","digest3");
+        mutationCache.addMutationMd5("mutation1","digest4");
+        assertEquals(3L, mutationCache.getMutationCRCs("mutation1").size());
+    }
+
+    @Test
+    public final void testIsProcessed() throws Exception {
+        MutationCache<String> mutationCache = new PersistentCache<>(3, 10, Duration.ofHours(1), path, String::getBytes);
+        assertFalse(mutationCache.isMutationProcessed("mutation1", "digest1"));
+        mutationCache.addMutationMd5("mutation1","digest1");
+        assertTrue(mutationCache.isMutationProcessed("mutation1", "digest1"));
+
+    }
+
+    @Test
+    public final void testPersistence() throws Exception {
+        PersistentCache<String> mutationCache = new PersistentCache<>(3, 10, Duration.ofHours(1), path, String::getBytes);
+        mutationCache.addMutationMd5("mutation1","digest1");
+        mutationCache.addMutationMd5("mutation1","digest2");
+        mutationCache.addMutationMd5("mutation1","digest3");
+
+        mutationCache.close();
+        mutationCache = new PersistentCache<>(3, 10, Duration.ofHours(1), path, String::getBytes);
+        assertEquals(3L, mutationCache.getMutationCRCs("mutation1").size());
+    }
+
+    @Test
+    public final void testMaxCapacity() throws Exception {
+        MutationCache<String> mutationCache = new PersistentCache<>(3, 10, Duration.ofHours(1), path, String::getBytes);
+
+        for (int i = 0; i <20; i++) {
+            mutationCache.addMutationMd5("mutation" + i, "digest" + i);
+        }
+
+        for (int i = 0; i < 20; i++) {
+            assertEquals(List.of("digest" + i), mutationCache.getMutationCRCs("mutation" + i));
+        }
+    }
+}

--- a/docs/docs-src/core/modules/ROOT/partials/cfgCassandraSource.adoc
+++ b/docs/docs-src/core/modules/ROOT/partials/cfgCassandraSource.adoc
@@ -187,4 +187,10 @@
 |
 | true
 
+| *cache.persistent.directory*
+| The directory where the persistent mutation cache will be stored. Formated as `{cache.persistent.directory}/{source-name}-{instance-id}` This setting is only used if the cache is persistent. If set, the connector will use RocksDB to store digests, otherwise it will use an in-memory cache.
+| string
+|
+| /data/source-cache
+
 |===

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,7 @@ kafkaVersion=3.4.0
 vavrVersion=0.10.3
 testContainersVersion=1.19.1
 caffeineVersion=2.8.8
+rocksdbVersion=9.4.0
 guavaVersion=30.1-jre
 messagingConnectorsCommonsVersion=1.0.14
 slf4jVersion=1.7.30


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

The Pull request implements Persistent Cache with RocksDB.

The implementation uses an in-memory cache mechanism using [Caffeine](https://github.com/ben-manes/caffeine) and a Write-through persistent cache based on [RocksDB](https://github.com/facebook/rocksdb).

## Fixes 

1. When there are too many mutation events (more than `cache.max.capacity`) being "processed" in a very short period of time, this can occur on high loads on the in-memory cache, causing eviction and duplication in the data topic.
2. When the connector restarts (manual restart operations or crashes) in between processing events arising from a single mutation, the data is wiped out from the in-memory cache but stays in the persistent cache.

## What's added/changed

- A new class named `PersistentCache.java` which implements the `MutationCache.java` interface, having the persistent cache implementation.
- A new configuration named `cache.persistent.directory` to enable the persistent cache and set the cache directory at the same time.
- Renamed the old `MutationCache.java` to `InMemory.java`, which has a non-persistent in-memory cache implementation.

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.

