### PR TITLE
Fix/primary key only table

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/connector/src/main/java/com/datastax/oss/cdc/CassandraClient.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/CassandraClient.java
@@ -42,6 +42,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
 import com.datastax.oss.driver.api.querybuilder.select.Select;
+import com.datastax.oss.driver.api.querybuilder.select.SelectFrom;
 import com.datastax.oss.driver.internal.core.auth.PlainTextAuthProvider;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultProgrammaticDriverConfigLoaderBuilder;
@@ -155,8 +156,8 @@ public class CassandraClient implements AutoCloseable {
 
     /**
      * Build a SELECT prepared statement for the first <i>pkLength</i> primary key columns.
-     * @param keyspaceName
-     * @param tableName
+     * @param keyspaceName keyspace name
+     * @param tableName table name
      * @param projection columns
      * @param pk primary key columns
      * @param pkLength primary key length
@@ -166,7 +167,8 @@ public class CassandraClient implements AutoCloseable {
                                            CqlIdentifier[] projection,
                                            CqlIdentifier[] pk,
                                            int pkLength) {
-        Select query = selectFrom(keyspaceName, tableName).columns(projection);
+        Select query = selectFrom(keyspaceName, tableName)
+                .columns(projection.length != 0 ? projection : pk);
         for (int i = 0; i < pkLength; i++)
             query = query.whereColumn(pk[i]).isEqualTo(bindMarker());
         query.limit(1);

--- a/connector/src/main/java/com/datastax/oss/cdc/CassandraClient.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/CassandraClient.java
@@ -167,6 +167,7 @@ public class CassandraClient implements AutoCloseable {
                                            CqlIdentifier[] projection,
                                            CqlIdentifier[] pk,
                                            int pkLength) {
+        // select columns according to projection array length
         Select query = selectFrom(keyspaceName, tableName)
                 .columns(projection.length != 0 ? projection : pk);
         for (int i = 0; i < pkLength; i++)

--- a/connector/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
@@ -355,6 +355,7 @@ public class CassandraSource implements Source<GenericRecord>, SchemaChangeListe
             List<ColumnMetadata> columns = tableMetadata.getColumns().values().stream()
                     // include primary keys in the json only output format options
                     // TODO: PERF: Infuse the key values instead of reading from DB https://github.com/datastax/cdc-apache-cassandra/issues/84
+                    // If primary key only table, then add all the columns into the value schema.
                     .filter(c -> config.isJsonOnlyOutputFormat() || isPrimaryKeyOnlyTable || !tableMetadata.getPrimaryKey().contains(c))
                     .filter(c -> !columnPattern.isPresent() || columnPattern.get().matcher(c.getName().asInternal()).matches())
                     .collect(Collectors.toList());

--- a/testcontainers/src/main/java/com/datastax/testcontainers/ChaosNetworkContainer.java
+++ b/testcontainers/src/main/java/com/datastax/testcontainers/ChaosNetworkContainer.java
@@ -34,7 +34,7 @@ public class ChaosNetworkContainer<SELF extends ChaosNetworkContainer<SELF>> ext
 
     public ChaosNetworkContainer(String targetContainer, String pause) {
         super(PUMBA_IMAGE);
-        setCommand("--log-level debug netem --tc-image gaiadocker/iproute2 --duration " + pause + " loss --percent 100 " + targetContainer);
+        setCommand("--log-level debug netem --tc-image ghcr.io/alexei-led/pumba-debian-nettools --duration " + pause + " loss --percent 100 " + targetContainer);
         addFileSystemBind("/var/run/docker.sock", "/var/run/docker.sock", BindMode.READ_WRITE);
         setWaitStrategy(Wait.forLogMessage(".*tc container created.*", 1));
         withLogConsumer(o -> {


### PR DESCRIPTION
## Fix

fixes #142 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

The Pull request fixes the connector issue, which doesn't support primary key-only tables.

In Cassandra, if there is any table with only primary key columns, 

Ex,
```sql
CREATE TABLE source.results (
    uuid           text,
    value          int,
	PRIMARY KEY ((uuid, value))
)
WITH cdc = TRUE;
```

then the connector throws an error because of an error in the SQL select statement formation. 
```bash
java.util.concurrent.CompletionException: com.datastax.oss.driver.api.core.servererrors.SyntaxError: line 1:7 no viable alternative at input 'FROM' (SELECT [FROM]...)
	at java.util.concurrent.CompletableFuture.reportJoin(CompletableFuture.java:412) ~[?:?]
	at java.util.concurrent.CompletableFuture.join(CompletableFuture.java:2044) ~[?:?]
	at com.datastax.oss.pulsar.source.CassandraSource.batchRead(CassandraSource.java:574) ~[?:?]
	at com.datastax.oss.pulsar.source.CassandraSource.maybeBatchRead(CassandraSource.java:463) ~[?:?]
	at com.datastax.oss.pulsar.source.CassandraSource.read(CassandraSource.java:455) ~[?:?]
```

## Considerations

There is confusion on the issue (#142) about what to push into the data topic when it's only a primary key table, and how to differentiate between a delete query and primary key-only table inserts.

To differentiate between the above-mentioned scenarios, we decided to send all the columns' data into the value field (including primary key columns) for insert and update for a primary key-only table.

The delete query data for all types of tables, including primary key-only tables, will have the value as `null` for AVRO and `{}` for JSON, as before.

## What's added/changed

- Database query statement is being resolved, which in turn fixes the above-mentioned issue.
- Added the pk columns on the value schema in case of a primary key-only table.

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.

