### PR TITLE
Fix - Cassandra CDC Connector Fails with ClassCastException for Timestamp Values in Collection Columns

### DIFF
--- a/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractNativeConverter.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/converters/AbstractNativeConverter.java
@@ -37,6 +37,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.pulsar.common.schema.SchemaType;
 
 import java.net.InetAddress;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -258,5 +259,36 @@ public abstract class AbstractNativeConverter<T> implements Converter<byte[], Ge
             default:
                 throw new UnsupportedOperationException("Unsupported type="+dataType.getProtocolCode()+" as key in a map");
         }
+    }
+
+    /**
+     * Converts a collection value based on its type.
+     * If the value is an {@link Instant}, it is converted to its epoch millisecond representation.
+     * Otherwise, the value is returned as is.
+     *
+     * @param collectionValue the value to be marshaled; could be an {@link Instant} or any other object
+     * @return the marshaled value; an epoch millisecond representation if the input is an {@link Instant}, or the original value otherwise
+     */
+    Object marshalCollectionValue(Object collectionValue) {
+        if(collectionValue instanceof Instant) {
+            return ((Instant)collectionValue).toEpochMilli();
+        }
+        return collectionValue;
+    }
+
+    /**
+     * Converts a collection value based on its type.
+     * If the value is an {@link Instant}, it is converted to its epoch millisecond representation.
+     * Otherwise, the value is returned as is.
+     *
+     * @param entry the value to be marshaled;
+     * @return the marshaled value; an epoch millisecond representation if the input is an {@link Instant}, or the original value otherwise
+     */
+    Object marshalCollectionValue(Map.Entry<? super Object, ? super Object> entry) {
+        Object collectionValue = entry.getValue();
+        if(collectionValue instanceof Instant) {
+            return ((Instant)collectionValue).toEpochMilli();
+        }
+        return collectionValue;
     }
 }


### PR DESCRIPTION
## Fix

fixes #195 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description

The Pull request fixes the connector issue, in which Cassandra CDC (Change Data Capture) Source Connector encounters a `ClassCastException` when processing data from tables that contain collection columns (list, map, or set) storing timestamp values.


## What's added/changed

- Custom Marshalling method for collection fields in `AbstractNativeConverter`, which checks for `Instant` type data and converts that to `long` data. 
- Integrated the new marshaling methods with collection columns (list, map, or set) converters.

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
