### PR TITLE
add rate limiter, batch.maxWaitMs, and cgroup-aware CPU detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,13 +49,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        module: ['agent', 'agent-c3', 'agent-c4', 'agent-dse4', 'connector']
+        module: ['agent', 'agent-c3', 'agent-c4', 'agent-dse4']
         jdk: ['11', '17']
         brokerImage:
           - 'pulsar|datastax/lunastreaming:2.10_3.4'
           - 'pulsar|apachepulsar/pulsar:2.10.3'
           - 'pulsar|apachepulsar/pulsar:2.11.0'
           - 'kafka|confluentinc/cp-kafka:7.4.0'
+        #
+        include:
+          - { module: connector, jdk: '11', brokerImage: 'kafka|confluentinc/cp-kafka:7.4.0', runBackfillCli: true }
+          - { module: connector, jdk: '17', brokerImage: 'kafka|confluentinc/cp-kafka:7.4.0', runBackfillCli: true }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4', testFilter: '--tests com.datastax.oss.pulsar.source.PulsarCassandraSourceTests --tests com.datastax.oss.cdc.CassandraSourceConnectorConfigTest --tests com.datastax.oss.cdc.MutationCacheTests', runBackfillCli: true }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4', testFilter: '--tests com.datastax.oss.pulsar.source.JsonOnlyCassandraSourceTests' }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4', testFilter: '--tests com.datastax.oss.pulsar.source.JsonKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4', testFilter: '--tests com.datastax.oss.pulsar.source.AvroKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4', testFilter: '--tests com.datastax.oss.pulsar.source.PulsarCassandraSourceTests --tests com.datastax.oss.cdc.CassandraSourceConnectorConfigTest --tests com.datastax.oss.cdc.MutationCacheTests', runBackfillCli: true }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4', testFilter: '--tests com.datastax.oss.pulsar.source.JsonOnlyCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4', testFilter: '--tests com.datastax.oss.pulsar.source.JsonKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4', testFilter: '--tests com.datastax.oss.pulsar.source.AvroKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|apachepulsar/pulsar:2.10.3', testFilter: '--tests com.datastax.oss.pulsar.source.PulsarCassandraSourceTests --tests com.datastax.oss.cdc.CassandraSourceConnectorConfigTest --tests com.datastax.oss.cdc.MutationCacheTests', runBackfillCli: true }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|apachepulsar/pulsar:2.10.3', testFilter: '--tests com.datastax.oss.pulsar.source.JsonOnlyCassandraSourceTests' }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|apachepulsar/pulsar:2.10.3', testFilter: '--tests com.datastax.oss.pulsar.source.JsonKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|apachepulsar/pulsar:2.10.3', testFilter: '--tests com.datastax.oss.pulsar.source.AvroKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|apachepulsar/pulsar:2.10.3', testFilter: '--tests com.datastax.oss.pulsar.source.PulsarCassandraSourceTests --tests com.datastax.oss.cdc.CassandraSourceConnectorConfigTest --tests com.datastax.oss.cdc.MutationCacheTests', runBackfillCli: true }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|apachepulsar/pulsar:2.10.3', testFilter: '--tests com.datastax.oss.pulsar.source.JsonOnlyCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|apachepulsar/pulsar:2.10.3', testFilter: '--tests com.datastax.oss.pulsar.source.JsonKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|apachepulsar/pulsar:2.10.3', testFilter: '--tests com.datastax.oss.pulsar.source.AvroKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|apachepulsar/pulsar:2.11.0', testFilter: '--tests com.datastax.oss.pulsar.source.PulsarCassandraSourceTests --tests com.datastax.oss.cdc.CassandraSourceConnectorConfigTest --tests com.datastax.oss.cdc.MutationCacheTests', runBackfillCli: true }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|apachepulsar/pulsar:2.11.0', testFilter: '--tests com.datastax.oss.pulsar.source.JsonOnlyCassandraSourceTests' }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|apachepulsar/pulsar:2.11.0', testFilter: '--tests com.datastax.oss.pulsar.source.JsonKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '11', brokerImage: 'pulsar|apachepulsar/pulsar:2.11.0', testFilter: '--tests com.datastax.oss.pulsar.source.AvroKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|apachepulsar/pulsar:2.11.0', testFilter: '--tests com.datastax.oss.pulsar.source.PulsarCassandraSourceTests --tests com.datastax.oss.cdc.CassandraSourceConnectorConfigTest --tests com.datastax.oss.cdc.MutationCacheTests', runBackfillCli: true }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|apachepulsar/pulsar:2.11.0', testFilter: '--tests com.datastax.oss.pulsar.source.JsonOnlyCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|apachepulsar/pulsar:2.11.0', testFilter: '--tests com.datastax.oss.pulsar.source.JsonKeyValueCassandraSourceTests' }
+          - { module: connector, jdk: '17', brokerImage: 'pulsar|apachepulsar/pulsar:2.11.0', testFilter: '--tests com.datastax.oss.pulsar.source.AvroKeyValueCassandraSourceTests' }
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.jdk }}
@@ -108,13 +136,16 @@ jobs:
 
           ./gradlew -Pdse4 -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
           $BROKER_FLAGS \
-          ${{ matrix.module }}:test
+          ${{ matrix.module }}:test ${{ matrix.testFilter }}
 
       # backfill-cli isn't in the module matrix above: its unit tests are broker-agnostic and its
       # e2e test needs the connector's nar, so it rides along on the connector matrix cell instead
-      # of running once per module.
+      # of running once per module. Gated on runBackfillCli (set on exactly one pulsar cell per
+      # jdk/image and the kafka cell) rather than module == 'connector', since connector's pulsar
+      # suite is now split across 4 cells and running this repeatedly would waste time without
+      # adding coverage.
       - name: Test backfill-cli
-        if: matrix.module == 'connector'
+        if: matrix.runBackfillCli == true
         env:
           DSE_REPO_USERNAME: ${{ secrets.DSE_REPO_USERNAME }}
           DSE_REPO_PASSWORD: ${{ secrets.DSE_REPO_PASSWORD }}
@@ -163,10 +194,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        module: ['agent', 'agent-c4', 'agent-dse4', 'connector']
+        module: ['agent', 'agent-c4', 'agent-dse4']
         brokerImage:
           - 'pulsar|datastax/lunastreaming:2.10_3.4'
           - 'kafka|confluentinc/cp-kafka:7.4.0'
+        # connector's pulsar suite is split across 4 cells below instead of joining the cross
+        # product above: JsonOnlyCassandraSourceTests/JsonKeyValueCassandraSourceTests/
+        # AvroKeyValueCassandraSourceTests each `extends PulsarCassandraSourceTests`, so a single
+        # "connector, pulsar" cell was re-running the same ~10 container/chaos scenarios 4x
+        # serially in one JVM (measured: ~104 of ~120 total minutes in one job). Splitting them
+        # into separate runners removes that serialization; it can't be parallelized with Gradle
+        # test forks in one job instead because CassandraContainer hardcodes container names
+        # (cassandra-1/cassandra-2), so concurrent classes in one job would collide.
+        include:
+          - module: connector
+            brokerImage: 'kafka|confluentinc/cp-kafka:7.4.0'
+            runBackfillCli: true
+          - module: connector
+            brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4'
+            testFilter: '--tests com.datastax.oss.pulsar.source.PulsarCassandraSourceTests --tests com.datastax.oss.cdc.CassandraSourceConnectorConfigTest --tests com.datastax.oss.cdc.MutationCacheTests'
+            runBackfillCli: true
+          - module: connector
+            brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4'
+            testFilter: '--tests com.datastax.oss.pulsar.source.JsonOnlyCassandraSourceTests'
+          - module: connector
+            brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4'
+            testFilter: '--tests com.datastax.oss.pulsar.source.JsonKeyValueCassandraSourceTests'
+          - module: connector
+            brokerImage: 'pulsar|datastax/lunastreaming:2.10_3.4'
+            testFilter: '--tests com.datastax.oss.pulsar.source.AvroKeyValueCassandraSourceTests'
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 11
@@ -219,13 +275,15 @@ jobs:
 
           ./gradlew -Pdse4 -PdseRepoUsername=$DSE_REPO_USERNAME -PdseRepoPassword=$DSE_REPO_PASSWORD \
           $BROKER_FLAGS \
-          ${{ matrix.module }}:test
+          ${{ matrix.module }}:test ${{ matrix.testFilter }}
 
       # backfill-cli isn't in the module matrix above: its unit tests are broker-agnostic and its
       # e2e test needs the connector's nar, so it rides along on the connector matrix cell instead
-      # of running once per module.
+      # of running once per module. Gated on runBackfillCli (set on exactly one pulsar cell and
+      # the kafka cell) rather than module == 'connector', since connector's pulsar suite is now
+      # split across 4 cells and running this 4x would waste time without adding coverage.
       - name: Test backfill-cli
-        if: matrix.module == 'connector'
+        if: matrix.runBackfillCli == true
         env:
           DSE_REPO_USERNAME: ${{ secrets.DSE_REPO_USERNAME }}
           DSE_REPO_PASSWORD: ${{ secrets.DSE_REPO_PASSWORD }}

--- a/connector/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
+++ b/connector/src/main/java/com/datastax/oss/cdc/CassandraSourceConnectorConfig.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.*;
 import java.util.function.Function;
@@ -47,6 +48,81 @@ import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.*;
 @SuppressWarnings("WeakerAccess")
 @Slf4j
 public class CassandraSourceConnectorConfig {
+
+    /**
+     * Returns the number of CPUs available to this JVM process, honouring the Linux cgroup CPU
+     * quota when present.
+     *
+     * <p><b>Kubernetes CPU limit vs. request:</b> this method reflects the pod's
+     * {@code resources.limits.cpu} value, <em>not</em> {@code resources.requests.cpu}.
+     * Only the CPU <em>limit</em> is enforced by the kernel via the CFS bandwidth controller
+     * ({@code cpu.cfs_quota_us} / {@code cpu.max}); the CPU <em>request</em> is used solely by
+     * the Kubernetes scheduler for bin-packing decisions and does not translate into any cgroup
+     * quota.
+     *
+     * <p><b>When no CPU limit is set on the pod</b> ({@code resources.limits.cpu} is absent),
+     * the kernel writes the "unlimited" sentinel into the cgroup — {@code "max <period>"} on
+     * cgroup v2, or {@code -1} for the quota on cgroup v1. Both cases are detected and skipped
+     * by this method, which then falls back to {@link Runtime#availableProcessors()}. On a
+     * bare-metal host or VM that value equals the total number of logical CPUs. Inside a
+     * container without a limit it still equals the host's CPU count, which may be much larger
+     * than what the pod actually gets scheduled on. Setting an explicit CPU limit in the pod spec
+     * is therefore recommended so that the default is well-bounded.
+     *
+     * <p><b>Why not just use {@link Runtime#availableProcessors()}?</b> This project targets
+     * <b>Java 8</b>. Container-awareness ({@code -XX:+UseContainerSupport}), which makes
+     * {@code availableProcessors()} respect the cgroup quota, was introduced in JDK 10 and
+     * back-ported only to JDK 8u191+, but is <em>not</em> enabled by default on JDK 8. Without
+     * this helper the default thread count would be derived from the host's total CPU count rather
+     * than the limit assigned to the pod.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>cgroup v2 — {@code /sys/fs/cgroup/cpu.max} ({@code "<quota> <period>"} or
+     *       {@code "max <period>"} when unlimited)</li>
+     *   <li>cgroup v1 — {@code /sys/fs/cgroup/cpu/cpu.cfs_quota_us} +
+     *       {@code cpu.cfs_period_us} ({@code -1} when unlimited)</li>
+     *   <li>Fallback — {@link Runtime#availableProcessors()}</li>
+     * </ol>
+     */
+    static int availableCpus() {
+        // cgroup v2: /sys/fs/cgroup/cpu.max  →  "<quota> <period>"  or  "max <period>"
+        // When no CPU limit is set on the pod, the kernel writes "max <period>" (the literal
+        // string "max" as the quota). We skip that case and fall through to the next check.
+        try {
+            Path cgroupV2 = Paths.get("/sys/fs/cgroup/cpu.max");
+            if (Files.exists(cgroupV2)) {
+                String[] parts = new String(Files.readAllBytes(cgroupV2)).trim().split("\\s+");
+                if (parts.length == 2 && !parts[0].equalsIgnoreCase("max")) {
+                    long quota  = Long.parseLong(parts[0]);
+                    long period = Long.parseLong(parts[1]);
+                    if (quota > 0 && period > 0) {
+                        return Math.max(1, (int) Math.ceil((double) quota / period));
+                    }
+                }
+            }
+        } catch (Exception ignored) { /* fall through */ }
+
+        // cgroup v1: /sys/fs/cgroup/cpu/cpu.cfs_quota_us + cpu.cfs_period_us
+        // When no CPU limit is set on the pod, the kernel writes -1 as the quota (meaning
+        // "no throttling"). We skip that case and fall through to the JVM fallback.
+        try {
+            Path quotaPath  = Paths.get("/sys/fs/cgroup/cpu/cpu.cfs_quota_us");
+            Path periodPath = Paths.get("/sys/fs/cgroup/cpu/cpu.cfs_period_us");
+            if (Files.exists(quotaPath) && Files.exists(periodPath)) {
+                long quota  = Long.parseLong(new String(Files.readAllBytes(quotaPath)).trim());
+                long period = Long.parseLong(new String(Files.readAllBytes(periodPath)).trim());
+                if (quota > 0 && period > 0) {  // quota == -1 means no limit; skip
+                    return Math.max(1, (int) Math.ceil((double) quota / period));
+                }
+            }
+        } catch (Exception ignored) { /* fall through */ }
+
+        // No cgroup quota found (no CPU limit set, not running in a container, or unsupported
+        // cgroup layout). Fall back to the JVM's view of available processors. Note that inside
+        // a container without a CPU limit this will return the host's total CPU count.
+        return Runtime.getRuntime().availableProcessors();
+    }
 
     public static final String KEYSPACE_NAME_CONFIG = "keyspace";
     public static final String TABLE_NAME_CONFIG = "table";
@@ -70,12 +146,14 @@ public class CassandraSourceConnectorConfig {
     public static final String INTERNAL_CONSUMER_SASL_JAAS_CONFIG_CONFIG = "internal.consumer.saslJaasConfig";
 
     public static final String BATCH_SIZE_CONFIG = "batch.size";
+    public static final String BATCH_MAX_WAIT_MS_CONFIG = "batch.maxWaitMs";
     public static final String QUERY_EXECUTORS_CONFIG = "query.executors";
     public static final String QUERY_MAX_TASKS_IN_QUEUE_CONFIG = "query.maxTasksInQueue";
     public static final String QUERY_MAX_MOBILE_AVG_LATENCY_CONFIG = "query.maxMobileAvgLatency";
     public static final String QUERY_MIN_MOBILE_AVG_LATENCY_CONFIG = "query.minMobileAvgLatency";
     public static final String QUERY_BACKOFF_IN_MS_CONFIG = "query.backoffInMs";
     public static final String QUERY_MAX_BACKOFF_IN_SEC_CONFIG = "query.maxBackoffInSec";
+    public static final String QUERY_RATE_LIMIT_CONFIG = "query.rateLimit";
 
     public static final String CACHE_ONLY_IF_COORDINATOR_MATCH = "cache.only_if_coordinator_match";
     public static final String CACHE_MAX_DIGESTS_CONFIG = "cache.max.digest";
@@ -258,19 +336,31 @@ public class CassandraSourceConnectorConfig {
                             200,
                             ConfigDef.Importance.MEDIUM,
                             "The batch size for grouping mutations before sending them to the data topic")
+                    .define(BATCH_MAX_WAIT_MS_CONFIG,
+                            ConfigDef.Type.LONG,
+                            1000L,
+                            ConfigDef.Range.atLeast(1),
+                            ConfigDef.Importance.MEDIUM,
+                            "Maximum time in milliseconds to wait for a full batch before flushing a partial one. "
+                            + "Prevents indefinite blocking when the events topic is very low-throughput "
+                            + "(e.g. only a few messages per day). Once this deadline is exceeded the loop "
+                            + "breaks and whatever records have been collected so far are returned, "
+                            + "even if fewer than batch.size.")
                     .define(QUERY_EXECUTORS_CONFIG,
                             ConfigDef.Type.INT,
-                            10,
+                            availableCpus() * 2,
                             ConfigDef.Importance.MEDIUM,
-                            "The number of threads to execute concurrent Cassandra queries (fixed pool size)")
+                            "The number of threads to execute concurrent Cassandra queries (fixed pool size). "
+                            + "Defaults to 2x the CPUs assigned to this pod/process (see availableCpus()).")
                     .define(QUERY_MAX_TASKS_IN_QUEUE_CONFIG,
                             ConfigDef.Type.INT,
-                            10000,
+                            availableCpus() * 20,
                             ConfigDef.Range.atLeast(1),
                             ConfigDef.Importance.MEDIUM,
                             "Maximum number of pending CQL query tasks per executor thread. When this limit is reached " +
                             "new submissions are rejected with a RejectedExecutionException, which the connector handles " +
-                            "as backpressure by pausing and retrying after a short delay.")
+                            "as backpressure by pausing and retrying after a short delay. " +
+                            "Defaults to 20x the CPUs assigned to this pod/process (see availableCpus()).")
                     .define(QUERY_MAX_MOBILE_AVG_LATENCY_CONFIG,
                             ConfigDef.Type.LONG,
                             100L,
@@ -292,6 +382,14 @@ public class CassandraSourceConnectorConfig {
                             3600L,
                             ConfigDef.Importance.MEDIUM,
                             "Maximum backoff delay in seconds when there is not enough Cassandra replicas to perform the query")
+                    .define(QUERY_RATE_LIMIT_CONFIG,
+                            ConfigDef.Type.DOUBLE,
+                            0.0,
+                            ConfigDef.Range.atLeast(0),
+                            ConfigDef.Importance.MEDIUM,
+                            "Maximum rate of Cassandra CQL queries per second across all executor threads. "
+                            + "Set to a positive value to cap the query throughput and protect the Cassandra cluster "
+                            + "from overload. A value of 0 (the default) disables the rate limiter.")
                     .define(CACHE_MAX_DIGESTS_CONFIG,
                             ConfigDef.Type.LONG,
                             "3",
@@ -769,6 +867,10 @@ public class CassandraSourceConnectorConfig {
         return globalConfig.getInt(BATCH_SIZE_CONFIG);
     }
 
+    public long getBatchMaxWaitMs() {
+        return globalConfig.getLong(BATCH_MAX_WAIT_MS_CONFIG);
+    }
+
     public String getEventsSubscriptionType() {
         return globalConfig.getString(EVENTS_SUBSCRIPTION_TYPE_CONFIG);
     }
@@ -803,6 +905,10 @@ public class CassandraSourceConnectorConfig {
 
     public long getQueryMaxBackoffInSec() {
         return globalConfig.getLong(QUERY_MAX_BACKOFF_IN_SEC_CONFIG);
+    }
+
+    public double getQueryRateLimit() {
+        return globalConfig.getDouble(QUERY_RATE_LIMIT_CONFIG);
     }
 
     public boolean getCacheOnlyIfCoordinatorMatch() {

--- a/connector/src/main/java/com/datastax/oss/kafka/source/KafkaCassandraSourceTask.java
+++ b/connector/src/main/java/com/datastax/oss/kafka/source/KafkaCassandraSourceTask.java
@@ -37,6 +37,7 @@ import com.datastax.oss.kafka.source.converters.KafkaAvroConverter;
 import com.datastax.oss.kafka.source.converters.KafkaJsonConverter;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.RateLimiter;
 import io.vavr.Tuple2;
 import io.vavr.Tuple3;
 import lombok.extern.slf4j.Slf4j;
@@ -89,6 +90,7 @@ public class KafkaCassandraSourceTask extends SourceTask implements SourceSchema
         final MutationValue mutationValue;
         final List<Object> pk;
         final String cacheKey;
+        CompletableFuture<SourceRecord> queryResult;
 
         DecodedRecord(ConsumerRecord<byte[], byte[]> rec, GenericRecord mutationKeyRecord,
                       MutationValue mutationValue, List<Object> pk, String cacheKey) {
@@ -120,6 +122,12 @@ public class KafkaCassandraSourceTask extends SourceTask implements SourceSchema
 
     OrderedExecutor queryExecutor;
     private long consecutiveUnavailableException = 0;
+
+    /**
+     * Optional rate limiter for Cassandra CQL queries.
+     * {@code null} when {@code query.rateLimit} is 0 (disabled).
+     */
+    private RateLimiter queryRateLimiter;
 
     private static final org.apache.avro.Schema MUTATION_VALUE_SCHEMA;
 
@@ -198,6 +206,11 @@ public class KafkaCassandraSourceTask extends SourceTask implements SourceSchema
                 .numThreads(config.getQueryExecutors())
                 .maxTasksInQueue(config.getQueryMaxTasksInQueue())
                 .build();
+        double rateLimit = config.getQueryRateLimit();
+        if (rateLimit > 0) {
+            this.queryRateLimiter = RateLimiter.create(rateLimit);
+            log.info("Cassandra query rate limiter enabled: {} queries/sec", rateLimit);
+        }
     }
 
     private Map<String, Object> sourcePartition(TopicPartition tp) {
@@ -362,7 +375,6 @@ public class KafkaCassandraSourceTask extends SourceTask implements SourceSchema
 
         // Decode all consumed records and submit CQL queries up-front.
         List<DecodedRecord> decodedRecs = new ArrayList<>();
-        List<CompletableFuture<SourceRecord>> futures = new ArrayList<>();
         for (ConsumerRecord<byte[], byte[]> rec : records) {
             GenericRecord mutationKeyRecord;
             List<Object> pk;
@@ -376,15 +388,15 @@ public class KafkaCassandraSourceTask extends SourceTask implements SourceSchema
             }
             String cacheKey = Base64.getEncoder().encodeToString(rec.key());
             DecodedRecord decoded = new DecodedRecord(rec, mutationKeyRecord, mutationValue, pk, cacheKey);
-            futures.add(submitCqlQuery(decoded, this.valueConverterAndQuery));
+            decoded.queryResult = submitCqlQuery(decoded, this.valueConverterAndQuery);
             decodedRecs.add(decoded);
         }
 
         // Phase 2 – wait for CQL queries, retrying per-record on failure.
         // Records are already consumed; we must not re-poll on CQL failure.
-        List<SourceRecord> sourceRecords = new ArrayList<>(futures.size());
-        for (int i = 0; i < futures.size(); i++) {
-            SourceRecord sourceRecord = waitForCqlWithRetry(decodedRecs.get(i), futures, i);
+        List<SourceRecord> sourceRecords = new ArrayList<>(decodedRecs.size());
+        for (DecodedRecord decoded : decodedRecs) {
+            SourceRecord sourceRecord = waitForCqlWithRetry(decoded);
             if (sourceRecord != null) {
                 sourceRecords.add(sourceRecord);
             }
@@ -408,6 +420,9 @@ public class KafkaCassandraSourceTask extends SourceTask implements SourceSchema
         try {
             queryExecutor.executeOrdered(decoded.cacheKey, () -> {
                 try {
+                    if (queryRateLimiter != null) {
+                        queryRateLimiter.acquire();
+                    }
                     if (mutationCache.isMutationProcessed(decoded.cacheKey, decoded.mutationValue.getMd5Digest())) {
                         future.complete(buildHeartbeatRecord(decoded.rec));
                         return;
@@ -446,13 +461,10 @@ public class KafkaCassandraSourceTask extends SourceTask implements SourceSchema
      * schema change that arrived while the query was failing is picked up automatically.
      */
     @SuppressWarnings("unchecked")
-    private SourceRecord waitForCqlWithRetry(
-            DecodedRecord decoded,
-            List<CompletableFuture<SourceRecord>> futures,
-            int index) throws InterruptedException {
+    private SourceRecord waitForCqlWithRetry(DecodedRecord decoded) throws InterruptedException {
         while (true) {
             try {
-                return futures.get(index).join();
+                return decoded.queryResult.join();
             } catch (CompletionException e) {
                 Throwable cause = e.getCause() != null ? e.getCause() : e;
                 if (cause instanceof ExecutionException && cause.getCause() != null) cause = cause.getCause();
@@ -464,7 +476,7 @@ public class KafkaCassandraSourceTask extends SourceTask implements SourceSchema
                 // Re-submit only the CQL query; the Kafka record is already consumed.
                 // Re-read valueConverterAndQuery so a schema change that arrived during the
                 // failure window is picked up for the retry.
-                futures.set(index, submitCqlQuery(decoded, this.valueConverterAndQuery));
+                decoded.queryResult = submitCqlQuery(decoded, this.valueConverterAndQuery);
             }
         }
     }

--- a/connector/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
+++ b/connector/src/main/java/com/datastax/oss/pulsar/source/CassandraSource.java
@@ -40,6 +40,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.RateLimiter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.vavr.Tuple2;
 import io.vavr.Tuple3;
@@ -164,6 +165,12 @@ public class CassandraSource implements Source<GenericRecord>, SourceSchemaChang
     private OrderedExecutor queryExecutor;
     private long consecutiveUnavailableException = 0;
 
+    /**
+     * Optional rate limiter for Cassandra CQL queries.
+     * {@code null} when {@code query.rateLimit} is 0 (disabled).
+     */
+    private RateLimiter queryRateLimiter;
+
     private ArrayBlockingQueue<CassandraRecord> buffer;
 
     public CassandraSource() {
@@ -212,6 +219,11 @@ public class CassandraSource implements Source<GenericRecord>, SourceSchemaChang
                     .numThreads(this.config.getQueryExecutors())
                     .maxTasksInQueue(this.config.getQueryMaxTasksInQueue())
                     .build();
+            double rateLimit = this.config.getQueryRateLimit();
+            if (rateLimit > 0) {
+                this.queryRateLimiter = RateLimiter.create(rateLimit);
+                log.info("Cassandra query rate limiter enabled: {} queries/sec", rateLimit);
+            }
         } catch (Throwable err) {
             log.error("Cannot open the connector:", err);
             throw new RuntimeException(err);
@@ -276,8 +288,7 @@ public class CassandraSource implements Source<GenericRecord>, SourceSchemaChang
                                  GenericRecord mutationKey,
                                  MutationValue mutationValue,
                                  List<Object> pk) {
-        final MyKVRecord kvRecord = new MyKVRecord(converterAndQueryFinal, keyValue, msg, mutationKey, mutationValue, pk);
-
+        MyKVRecord kvRecord = new MyKVRecord(converterAndQueryFinal, keyValue, msg, mutationKey, mutationValue, pk);
         return config.isJsonOnlyOutputFormat() ? new JsonValueRecord(kvRecord) : kvRecord;
     }
 
@@ -327,8 +338,25 @@ public class CassandraSource implements Source<GenericRecord>, SourceSchemaChang
         // Phase 1 – consume from the events topic.
         // If consumer.receive() throws we retry the entire consume loop forever (safe: no message
         // has been delivered yet, so re-polling does not double-consume anything).
+         //
+        // Two conditions bound the loop:
+        //   1. batch.size      — stop once we have enough records (normal high-throughput path).
+        //   2. batch.maxWaitMs — stop once the wall-clock deadline is reached, but only when at
+        //                        least one record has been collected. This prevents indefinite
+        //                        blocking on very low-throughput topics (e.g. 1 msg/day): without
+        //                        this deadline the loop would keep spinning on empty receive()
+        //                        timeouts and never flush the partial batch. We never break on an
+        //                        empty batch so that the caller's retry loop in maybeBatchRead()
+        //                        is not triggered unnecessarily.
         List<CassandraRecord> newRecords = new ArrayList<>();
+        final long batchDeadlineMs = System.currentTimeMillis() + this.config.getBatchMaxWaitMs();
         while (newRecords.size() < this.config.getBatchSize()) {
+            if (!newRecords.isEmpty() && System.currentTimeMillis() >= batchDeadlineMs) {
+                if (log.isDebugEnabled()) {
+                    log.debug("batch.maxWaitMs deadline reached, flushing partial batch of {} record(s)", newRecords.size());
+                }
+                break;
+            }
             final Message<KeyValue<GenericRecord, MutationValue>> msg;
             try {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
@@ -416,6 +444,9 @@ public class CassandraSource implements Source<GenericRecord>, SourceSchemaChang
         try {
             queryExecutor.executeOrdered(msg.getKey(), () -> {
                 try {
+                    if (queryRateLimiter != null) {
+                        queryRateLimiter.acquire();
+                    }
                     if (mutationCache.isMutationProcessed(msg.getKey(), mutationValue.getMd5Digest())) {
                         if (log.isDebugEnabled()) {
                             log.debug("Message key={} md5={} already processed", msg.getKey(), mutationValue.getMd5Digest());

--- a/connector/src/test/java/com/datastax/oss/kafka/source/KafkaCassandraSourceTaskRetryTest.java
+++ b/connector/src/test/java/com/datastax/oss/kafka/source/KafkaCassandraSourceTaskRetryTest.java
@@ -1,0 +1,397 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.kafka.source;
+
+import com.datastax.oss.cdc.CassandraClient;
+import com.datastax.oss.cdc.CassandraSourceConnectorConfig;
+import com.datastax.oss.cdc.ConverterAndQuery;
+import com.datastax.oss.cdc.MutationCache;
+import com.datastax.oss.cdc.MutationValue;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.kafka.source.converters.Converter;
+import io.vavr.Tuple3;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the CQL query retry behaviour in {@link KafkaCassandraSourceTask}.
+ *
+ * <p>The production path is:
+ * <ol>
+ *   <li>{@code submitCqlQuery} submits the CQL work to the {@link OrderedExecutor} and returns a
+ *       future.</li>
+ *   <li>{@code waitForCqlWithRetry} blocks on that future; when it completes exceptionally it
+ *       backs off and re-submits <em>only the CQL query</em> (never re-polls the events topic).</li>
+ * </ol>
+ *
+ * <p>Tests here exercise these two private methods via reflection so that the full retry loop
+ * can be verified without standing up a real Kafka broker or a real Cassandra node.
+ */
+public class KafkaCassandraSourceTaskRetryTest {
+
+    private KafkaCassandraSourceTask task;
+    private CassandraClient mockClient;
+    private ConverterAndQuery<Converter<byte[], ?>> mockCaq;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() throws Exception {
+        task = new KafkaCassandraSourceTask();
+
+        // Minimal config: 0 ms backoff so tests run fast.
+        CassandraSourceConnectorConfig config = minimalConfig();
+        setField(task, "config", config);
+
+        mockClient = mock(CassandraClient.class);
+        setField(task, "cassandraClient", mockClient);
+
+        // A real OrderedExecutor so tasks actually execute.
+        OrderedExecutor executor = OrderedExecutor.newBuilder()
+                .name("test-retry-executor")
+                .numThreads(2)
+                .maxTasksInQueue(100)
+                .build();
+        setField(task, "queryExecutor", executor);
+
+        // Empty mutation cache.
+        MutationCache<String> cache = new MutationCache<>(3, 100, Duration.ofMinutes(1));
+        setField(task, "mutationCache", cache);
+
+        // Rate limiter disabled.
+        setField(task, "queryRateLimiter", null);
+
+        // valueConverterAndQuery mock.
+        mockCaq = mock(ConverterAndQuery.class);
+        when(mockCaq.getConverter()).thenReturn(mock(Converter.class));
+        when(mockCaq.prepareSelectStatement(any(), anyInt())).thenReturn(mock(PreparedStatement.class));
+        setField(task, "valueConverterAndQuery", mockCaq);
+
+        // emptyValue
+        setField(task, "emptyValue", null);
+
+        // Mock key converter.
+        Converter<byte[], ?> keyConverter = mock(Converter.class);
+        when(keyConverter.fromConnectData(any(GenericRecord.class))).thenReturn(new byte[]{1, 2, 3});
+        setField(task, "keyConverter", keyConverter);
+
+        // consecutiveUnavailableException counter
+        setField(task, "consecutiveUnavailableException", 0L);
+
+        // output + heartbeat topics
+        setField(task, "outputTopic", "output-topic");
+        setField(task, "heartbeatTopic", "output-topic-heartbeat");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        OrderedExecutor executor = (OrderedExecutor) getField(task, "queryExecutor");
+        if (executor != null) {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * When {@code cassandraClient.selectRow} throws on the first call and succeeds on the second,
+     * {@code waitForCqlWithRetry} must retry exactly once and return the result from the second call.
+     */
+    @Test
+    void retries_once_after_single_cql_failure() throws Exception {
+        Row mockRow = mock(Row.class);
+        UUID nodeId = UUID.randomUUID();
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        when(mockClient.selectRow(anyList(), any(), anyList(), any(), anyString()))
+                .thenAnswer(inv -> {
+                    if (callCount.incrementAndGet() == 1) {
+                        throw new RuntimeException("Simulated CQL failure");
+                    }
+                    return new Tuple3<>(mockRow, ConsistencyLevel.LOCAL_QUORUM, nodeId);
+                });
+
+        // Converter returns non-null bytes for the row.
+        @SuppressWarnings("unchecked")
+        Converter<byte[], ?> valueConverter = (Converter<byte[], ?>) mockCaq.getConverter();
+        when(valueConverter.toConnectData(mockRow)).thenReturn(new byte[]{10, 20});
+
+        DecodedRecordProxy decoded = buildDecodedRecord(nodeId, "digest-1");
+
+        // Submit the initial CQL query.
+        CompletableFuture<SourceRecord> future = invokeSubmitCqlQuery(decoded, mockCaq);
+        decoded.setQueryResult(future);
+
+        // waitForCqlWithRetry should recover and return a non-null record.
+        SourceRecord result = invokeWaitForCqlWithRetry(decoded);
+
+        assertNotNull(result, "Expected a SourceRecord after one retry");
+        assertEquals("output-topic", result.topic());
+        verify(mockClient, times(2)).selectRow(anyList(), any(), anyList(), any(), anyString());
+    }
+
+    /**
+     * When {@code cassandraClient.selectRow} fails three times before succeeding, the retry loop
+     * must try exactly four times in total and ultimately deliver the result.
+     */
+    @Test
+    void retries_multiple_times_until_success() throws Exception {
+        Row mockRow = mock(Row.class);
+        UUID nodeId = UUID.randomUUID();
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        when(mockClient.selectRow(anyList(), any(), anyList(), any(), anyString()))
+                .thenAnswer(inv -> {
+                    if (callCount.incrementAndGet() < 4) {
+                        throw new RuntimeException("Simulated CQL failure #" + callCount.get());
+                    }
+                    return new Tuple3<>(mockRow, ConsistencyLevel.LOCAL_QUORUM, nodeId);
+                });
+
+        @SuppressWarnings("unchecked")
+        Converter<byte[], ?> valueConverter = (Converter<byte[], ?>) mockCaq.getConverter();
+        when(valueConverter.toConnectData(mockRow)).thenReturn(new byte[]{5});
+
+        DecodedRecordProxy decoded = buildDecodedRecord(nodeId, "digest-multi");
+        decoded.setQueryResult(invokeSubmitCqlQuery(decoded, mockCaq));
+
+        SourceRecord result = invokeWaitForCqlWithRetry(decoded);
+
+        assertNotNull(result, "Expected a SourceRecord after multiple retries");
+        verify(mockClient, times(4)).selectRow(anyList(), any(), anyList(), any(), anyString());
+    }
+
+    /**
+     * When the mutation digest is already cached (dedup cache hit), {@code submitCqlQuery} must
+     * emit a heartbeat record and {@code waitForCqlWithRetry} must return it without calling
+     * {@code selectRow} at all.
+     */
+    @Test
+    void cache_hit_skips_cql_query_and_returns_heartbeat() throws Exception {
+        String cacheKey = "cached-key";
+        String md5 = "digest-cached";
+
+        // Pre-populate the cache.
+        MutationCache<String> cache = (MutationCache<String>) getField(task, "mutationCache");
+        cache.addMutationMd5(cacheKey, md5);
+
+        DecodedRecordProxy decoded = buildDecodedRecordWithCacheKey(cacheKey, UUID.randomUUID(), md5);
+        decoded.setQueryResult(invokeSubmitCqlQuery(decoded, mockCaq));
+
+        SourceRecord result = invokeWaitForCqlWithRetry(decoded);
+
+        // Should be a heartbeat (non-null, sent to heartbeat topic).
+        assertNotNull(result, "Expected a heartbeat record for cache hit");
+        assertEquals("output-topic-heartbeat", result.topic());
+        verify(mockClient, times(0)).selectRow(anyList(), any(), anyList(), any(), anyString());
+    }
+
+    /**
+     * When a null row is returned (the row was deleted before the read-back), the resulting
+     * SourceRecord should still be emitted (using {@code emptyValue = null}).
+     */
+    @Test
+    void null_row_produces_source_record_with_null_value() throws Exception {
+        UUID nodeId = UUID.randomUUID();
+        // selectRow returns null row (row was deleted)
+        when(mockClient.selectRow(anyList(), any(), anyList(), any(), anyString()))
+                .thenReturn(new Tuple3<>(null, ConsistencyLevel.LOCAL_QUORUM, nodeId));
+
+        DecodedRecordProxy decoded = buildDecodedRecord(nodeId, "digest-delete");
+        decoded.setQueryResult(invokeSubmitCqlQuery(decoded, mockCaq));
+
+        SourceRecord result = invokeWaitForCqlWithRetry(decoded);
+
+        assertNotNull(result, "Expected a SourceRecord even for a deleted row");
+        assertNull(result.value(), "Value should be null (emptyValue) for a deleted row");
+        verify(mockClient, times(1)).selectRow(anyList(), any(), anyList(), any(), anyString());
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Minimal in-process config with zero backoff so retry loops complete instantly.
+     */
+    private static CassandraSourceConnectorConfig minimalConfig() {
+        java.util.Map<String, String> props = new java.util.HashMap<>();
+        props.put(CassandraSourceConnectorConfig.KEYSPACE_NAME_CONFIG, "ks1");
+        props.put(CassandraSourceConnectorConfig.TABLE_NAME_CONFIG, "t1");
+        props.put(CassandraSourceConnectorConfig.EVENTS_TOPIC_NAME_CONFIG, "events-ks1.t1");
+        props.put(CassandraSourceConnectorConfig.QUERY_BACKOFF_IN_MS_CONFIG, "0");
+        props.put(CassandraSourceConnectorConfig.QUERY_MAX_BACKOFF_IN_SEC_CONFIG, "3600");
+        props.put(CassandraSourceConnectorConfig.OUTPUT_TOPIC_CONFIG, "output-topic");
+        props.put(CassandraSourceConnectorConfig.INTERNAL_CONSUMER_BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        return new CassandraSourceConnectorConfig(props);
+    }
+
+    /** Builds a {@link DecodedRecordProxy} backed by a real {@link ConsumerRecord}. */
+    private DecodedRecordProxy buildDecodedRecord(UUID nodeId, String md5) throws Exception {
+        return buildDecodedRecordWithCacheKey("test-cache-key-" + md5, nodeId, md5);
+    }
+
+    private DecodedRecordProxy buildDecodedRecordWithCacheKey(String cacheKey, UUID nodeId, String md5) throws Exception {
+        ConsumerRecord<byte[], byte[]> rec = new ConsumerRecord<>(
+                "events-ks1.t1", 0, 0L, new byte[]{1}, new byte[]{2});
+        MutationValue mutationValue = new MutationValue(md5, nodeId, null);
+
+        // Build a minimal Avro GenericRecord for the mutationKeyRecord field.
+        Schema avroSchema = SchemaBuilder.record("MutationKey").fields()
+                .name("id").type().stringType().noDefault()
+                .endRecord();
+        GenericRecord mutationKeyRecord = new GenericData.Record(avroSchema);
+        mutationKeyRecord.put("id", "row1");
+
+        List<Object> pk = Collections.singletonList("row1");
+        return new DecodedRecordProxy(rec, mutationKeyRecord, mutationValue, pk, cacheKey);
+    }
+
+    /** Invokes the private {@code submitCqlQuery} via reflection. */
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<SourceRecord> invokeSubmitCqlQuery(
+            DecodedRecordProxy decoded, ConverterAndQuery<Converter<byte[], ?>> caq) throws Exception {
+        // Build the real inner DecodedRecord instance from the proxy.
+        Object innerDecoded = decoded.toInner(task);
+        Method m = KafkaCassandraSourceTask.class.getDeclaredMethod(
+                "submitCqlQuery", Class.forName(
+                        "com.datastax.oss.kafka.source.KafkaCassandraSourceTask$DecodedRecord"),
+                ConverterAndQuery.class);
+        m.setAccessible(true);
+        return (CompletableFuture<SourceRecord>) m.invoke(task, innerDecoded, caq);
+    }
+
+    /** Invokes the private {@code waitForCqlWithRetry} via reflection. */
+    private SourceRecord invokeWaitForCqlWithRetry(DecodedRecordProxy decoded) throws Exception {
+        Object innerDecoded = decoded.toInner(task);
+        // Update the queryResult field on the inner object to match the proxy's current future.
+        Field qrField = innerDecoded.getClass().getDeclaredField("queryResult");
+        qrField.setAccessible(true);
+        qrField.set(innerDecoded, decoded.getQueryResult());
+
+        Method m = KafkaCassandraSourceTask.class.getDeclaredMethod(
+                "waitForCqlWithRetry", Class.forName(
+                        "com.datastax.oss.kafka.source.KafkaCassandraSourceTask$DecodedRecord"));
+        m.setAccessible(true);
+        return (SourceRecord) m.invoke(task, innerDecoded);
+    }
+
+    // ── reflection helpers ────────────────────────────────────────────────────────
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                Field f = clazz.getDeclaredField(name);
+                f.setAccessible(true);
+                f.set(target, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in " + target.getClass());
+    }
+
+    private static Object getField(Object target, String name) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                Field f = clazz.getDeclaredField(name);
+                f.setAccessible(true);
+                return f.get(target);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in " + target.getClass());
+    }
+
+    /**
+     * A value-holder that mirrors the private inner {@code DecodedRecord} class, with a mutable
+     * {@code queryResult}. Used to set up test state; converted to a real inner instance before
+     * being passed to the task's private methods.
+     */
+    private static class DecodedRecordProxy {
+        final ConsumerRecord<byte[], byte[]> rec;
+        final GenericRecord mutationKeyRecord;
+        final MutationValue mutationValue;
+        final List<Object> pk;
+        final String cacheKey;
+        private CompletableFuture<SourceRecord> queryResult;
+
+        // Cache the constructed inner object so we always return the same instance.
+        private Object innerInstance;
+
+        DecodedRecordProxy(ConsumerRecord<byte[], byte[]> rec, GenericRecord mutationKeyRecord,
+                           MutationValue mutationValue, List<Object> pk, String cacheKey) {
+            this.rec = rec;
+            this.mutationKeyRecord = mutationKeyRecord;
+            this.mutationValue = mutationValue;
+            this.pk = pk;
+            this.cacheKey = cacheKey;
+        }
+
+        void setQueryResult(CompletableFuture<SourceRecord> future) {
+            this.queryResult = future;
+        }
+
+        CompletableFuture<SourceRecord> getQueryResult() {
+            return queryResult;
+        }
+
+        /** Lazily constructs (and caches) the real private inner-class instance via reflection. */
+        Object toInner(KafkaCassandraSourceTask task) throws Exception {
+            if (innerInstance != null) return innerInstance;
+            Class<?> innerClass = Class.forName(
+                    "com.datastax.oss.kafka.source.KafkaCassandraSourceTask$DecodedRecord");
+            java.lang.reflect.Constructor<?> ctor = innerClass.getDeclaredConstructor(
+                    ConsumerRecord.class, GenericRecord.class,
+                    MutationValue.class, List.class, String.class);
+            ctor.setAccessible(true);
+            innerInstance = ctor.newInstance(rec, mutationKeyRecord, mutationValue, pk, cacheKey);
+            return innerInstance;
+        }
+    }
+}

--- a/connector/src/test/java/com/datastax/oss/pulsar/source/CassandraSourceRetryTest.java
+++ b/connector/src/test/java/com/datastax/oss/pulsar/source/CassandraSourceRetryTest.java
@@ -1,0 +1,432 @@
+/**
+ * Copyright DataStax, Inc 2021.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.source;
+
+import com.datastax.oss.cdc.CassandraClient;
+import com.datastax.oss.cdc.CassandraSourceConnectorConfig;
+import com.datastax.oss.cdc.ConverterAndQuery;
+import com.datastax.oss.cdc.MutationCache;
+import com.datastax.oss.cdc.MutationValue;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.Row;
+import io.vavr.Tuple3;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.core.SourceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the CQL query retry behaviour in {@link CassandraSource}.
+ *
+ * <p>The retry path under test is:
+ * <ol>
+ *   <li>{@code submitCqlQuery} submits CQL work to the {@link OrderedExecutor} and returns a
+ *       future.</li>
+ *   <li>{@code waitForCqlWithRetry} blocks on that future; on {@link java.util.concurrent.CompletionException}
+ *       it backs off and re-submits <em>only the CQL query</em> — never re-consumes from the
+ *       events topic.</li>
+ * </ol>
+ *
+ * <p>Both private methods are called via reflection. The private {@code CassandraRecord} interface
+ * is implemented by a {@link Proxy} so it can be passed directly to
+ * {@code waitForCqlWithRetry} without constructing the inner {@code MyKVRecord}.
+ */
+public class CassandraSourceRetryTest {
+
+    private CassandraSource source;
+    private CassandraClient mockClient;
+    @SuppressWarnings("unchecked")
+    private ConverterAndQuery<Converter> mockCaq;
+    @SuppressWarnings("unchecked")
+    private Consumer<KeyValue<org.apache.pulsar.client.api.schema.GenericRecord, MutationValue>> mockConsumer;
+    private SourceContext mockSourceContext;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() throws Exception {
+        source = new CassandraSource();
+
+        CassandraSourceConnectorConfig config = minimalConfig();
+        setField(source, "config", config);
+
+        mockClient = mock(CassandraClient.class);
+        setField(source, "cassandraClient", mockClient);
+
+        OrderedExecutor executor = OrderedExecutor.newBuilder()
+                .name("test-pulsar-retry-executor")
+                .numThreads(2)
+                .maxTasksInQueue(100)
+                .build();
+        setField(source, "queryExecutor", executor);
+
+        MutationCache<String> cache = new MutationCache<>(3, 100, Duration.ofMinutes(1));
+        setField(source, "mutationCache", cache);
+
+        setField(source, "queryRateLimiter", null);
+
+        mockCaq = mock(ConverterAndQuery.class);
+        Converter mockConverter = mock(Converter.class);
+        when(mockCaq.getConverter()).thenReturn(mockConverter);
+        when(mockCaq.prepareSelectStatement(any(), anyInt())).thenReturn(mock(PreparedStatement.class));
+        setField(source, "valueConverterAndQuery", mockCaq);
+
+        setField(source, "emptyValue", null);
+
+        // keyConverter: fromConnectData returns a byte[]
+        Converter mockKeyConverter = mock(Converter.class);
+        when(mockKeyConverter.fromConnectData(any())).thenReturn(new byte[]{1, 2, 3});
+        setField(source, "keyConverter", mockKeyConverter);
+
+        setField(source, "consecutiveUnavailableException", 0L);
+
+        // Mock the Pulsar consumer (only needed for acknowledge() on cache hits).
+        mockConsumer = mock(Consumer.class);
+        doNothing().when(mockConsumer).acknowledge(any(Message.class));
+        setField(source, "consumer", mockConsumer);
+
+        // Mock SourceContext so recordMetric calls don't NPE.
+        mockSourceContext = mock(SourceContext.class);
+        doNothing().when(mockSourceContext).recordMetric(anyString(), anyDouble());
+        when(mockSourceContext.getSourceName()).thenReturn("test-source");
+        setField(source, "sourceContext", mockSourceContext);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        OrderedExecutor executor = (OrderedExecutor) getField(source, "queryExecutor");
+        if (executor != null) {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * When {@code cassandraClient.selectRow} throws on the first call and succeeds on the second,
+     * {@code waitForCqlWithRetry} must retry exactly once and return the non-null result.
+     */
+    @Test
+    void retries_once_after_single_cql_failure() throws Exception {
+        Row mockRow = mock(Row.class);
+        UUID nodeId = UUID.randomUUID();
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        when(mockClient.selectRow(anyList(), any(), anyList(), any(), anyString()))
+                .thenAnswer(inv -> {
+                    if (callCount.incrementAndGet() == 1) {
+                        throw new RuntimeException("Simulated CQL failure");
+                    }
+                    return new Tuple3<>(mockRow, ConsistencyLevel.LOCAL_QUORUM, nodeId);
+                });
+
+        @SuppressWarnings("unchecked")
+        Converter valueConverter = mockCaq.getConverter();
+        when(valueConverter.toConnectData(mockRow)).thenReturn(new byte[]{10, 20});
+
+        RecordProxy proxy = buildRecord(nodeId, "digest-1");
+        proxy.setQueryResult(invokeSubmitCqlQuery(proxy));
+
+        KeyValue<Object, Object> result = invokeWaitForCqlWithRetry(proxy);
+
+        assertNotNull(result, "Expected a KeyValue result after one retry");
+        assertNotNull(result.getValue(), "Value should be the converted row bytes");
+        verify(mockClient, times(2)).selectRow(anyList(), any(), anyList(), any(), anyString());
+    }
+
+    /**
+     * When {@code cassandraClient.selectRow} fails three times before succeeding, the retry loop
+     * must call selectRow exactly four times and ultimately deliver the result.
+     */
+    @Test
+    void retries_multiple_times_until_success() throws Exception {
+        Row mockRow = mock(Row.class);
+        UUID nodeId = UUID.randomUUID();
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        when(mockClient.selectRow(anyList(), any(), anyList(), any(), anyString()))
+                .thenAnswer(inv -> {
+                    if (callCount.incrementAndGet() < 4) {
+                        throw new RuntimeException("Simulated CQL failure #" + callCount.get());
+                    }
+                    return new Tuple3<>(mockRow, ConsistencyLevel.LOCAL_QUORUM, nodeId);
+                });
+
+        @SuppressWarnings("unchecked")
+        Converter valueConverter = mockCaq.getConverter();
+        when(valueConverter.toConnectData(mockRow)).thenReturn(new byte[]{5});
+
+        RecordProxy proxy = buildRecord(nodeId, "digest-multi");
+        proxy.setQueryResult(invokeSubmitCqlQuery(proxy));
+
+        KeyValue<Object, Object> result = invokeWaitForCqlWithRetry(proxy);
+
+        assertNotNull(result, "Expected a KeyValue result after multiple retries");
+        verify(mockClient, times(4)).selectRow(anyList(), any(), anyList(), any(), anyString());
+    }
+
+    /**
+     * When the mutation digest is already in the dedup cache, {@code submitCqlQuery} must
+     * complete the future with {@code null} (cache-hit sentinel) and {@code waitForCqlWithRetry}
+     * must return {@code null} without ever calling {@code selectRow}.
+     */
+    @Test
+    void cache_hit_returns_null_without_cql_query() throws Exception {
+        String cacheKey = "cache-key-hit";
+        String md5 = "digest-cached";
+
+        MutationCache<String> cache = (MutationCache<String>) getField(source, "mutationCache");
+        cache.addMutationMd5(cacheKey, md5);
+
+        RecordProxy proxy = buildRecordWithKey(cacheKey, UUID.randomUUID(), md5);
+        proxy.setQueryResult(invokeSubmitCqlQuery(proxy));
+
+        KeyValue<Object, Object> result = invokeWaitForCqlWithRetry(proxy);
+
+        assertNull(result, "Cache hit must return null (duplicate-mutation sentinel)");
+        verify(mockClient, times(0)).selectRow(anyList(), any(), anyList(), any(), anyString());
+        // The consumer must acknowledge the duplicate message so the offset advances.
+        verify(mockConsumer, times(1)).acknowledge(any(Message.class));
+    }
+
+    /**
+     * When {@code selectRow} returns a null row (the row was deleted before read-back), the
+     * future completes with a KeyValue whose value is the configured {@code emptyValue} (null
+     * here). The result must be non-null (the KeyValue wrapper itself must be present).
+     */
+    @Test
+    void null_row_produces_key_value_with_null_value() throws Exception {
+        UUID nodeId = UUID.randomUUID();
+        when(mockClient.selectRow(anyList(), any(), anyList(), any(), anyString()))
+                .thenReturn(new Tuple3<>(null, ConsistencyLevel.LOCAL_QUORUM, nodeId));
+
+        RecordProxy proxy = buildRecord(nodeId, "digest-delete");
+        proxy.setQueryResult(invokeSubmitCqlQuery(proxy));
+
+        KeyValue<Object, Object> result = invokeWaitForCqlWithRetry(proxy);
+
+        assertNotNull(result, "Expected a KeyValue wrapper even for a deleted row");
+        assertNull(result.getValue(), "Value should be null (emptyValue) for a deleted row");
+        verify(mockClient, times(1)).selectRow(anyList(), any(), anyList(), any(), anyString());
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────
+
+    /** Minimal config with zero backoff so retry loops finish instantly in tests. */
+    private static CassandraSourceConnectorConfig minimalConfig() {
+        Map<String, String> props = new HashMap<>();
+        props.put(CassandraSourceConnectorConfig.KEYSPACE_NAME_CONFIG, "ks1");
+        props.put(CassandraSourceConnectorConfig.TABLE_NAME_CONFIG, "t1");
+        props.put(CassandraSourceConnectorConfig.EVENTS_TOPIC_NAME_CONFIG, "events-ks1.t1");
+        props.put(CassandraSourceConnectorConfig.QUERY_BACKOFF_IN_MS_CONFIG, "0");
+        props.put(CassandraSourceConnectorConfig.QUERY_MAX_BACKOFF_IN_SEC_CONFIG, "3600");
+        return new CassandraSourceConnectorConfig(props);
+    }
+
+    private RecordProxy buildRecord(UUID nodeId, String md5) {
+        return buildRecordWithKey("msg-key-" + md5, nodeId, md5);
+    }
+
+    @SuppressWarnings("unchecked")
+    private RecordProxy buildRecordWithKey(String msgKey, UUID nodeId, String md5) {
+        MutationValue mutationValue = new MutationValue(md5, nodeId, null);
+
+        // Mock a Pulsar Message with the minimal surface the production code calls.
+        Message<KeyValue<org.apache.pulsar.client.api.schema.GenericRecord, MutationValue>> msg =
+                mock(Message.class);
+        when(msg.getKey()).thenReturn(msgKey);
+        when(msg.getKeyBytes()).thenReturn(msgKey.getBytes());
+        when(msg.getMessageId()).thenReturn(mock(MessageId.class));
+        when(msg.hasProperty(anyString())).thenReturn(false);
+
+        // Mock mutationKey (Pulsar GenericRecord).
+        org.apache.pulsar.client.api.schema.GenericRecord mutationKey =
+                mock(org.apache.pulsar.client.api.schema.GenericRecord.class);
+        when(mutationKey.getNativeObject()).thenReturn(new Object());
+
+        List<Object> pk = Collections.singletonList("row1");
+        return new RecordProxy(msg, mutationKey, mutationValue, pk);
+    }
+
+    /**
+     * Invokes the private {@code submitCqlQuery} method via reflection, passing a mocked
+     * {@code Message} plus the pre-decoded fields that the production code normally computes
+     * during {@code batchRead}.
+     */
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<KeyValue<Object, Object>> invokeSubmitCqlQuery(RecordProxy proxy)
+            throws Exception {
+        Method m = CassandraSource.class.getDeclaredMethod(
+                "submitCqlQuery",
+                Message.class,
+                org.apache.pulsar.client.api.schema.GenericRecord.class,
+                MutationValue.class,
+                List.class,
+                ConverterAndQuery.class);
+        m.setAccessible(true);
+        return (CompletableFuture<KeyValue<Object, Object>>) m.invoke(
+                source,
+                proxy.msg,
+                proxy.mutationKey,
+                proxy.mutationValue,
+                proxy.pk,
+                mockCaq);
+    }
+
+    /**
+     * Invokes the private {@code waitForCqlWithRetry} method via reflection, wrapping the proxy's
+     * mutable state in a dynamic proxy that implements the private {@code CassandraRecord}
+     * interface.
+     */
+    @SuppressWarnings("unchecked")
+    private KeyValue<Object, Object> invokeWaitForCqlWithRetry(RecordProxy proxy) throws Exception {
+        // Locate the private CassandraRecord interface by name.
+        Class<?> cassandraRecordIface = null;
+        for (Class<?> c : CassandraSource.class.getDeclaredClasses()) {
+            if (c.getSimpleName().equals("CassandraRecord")) {
+                cassandraRecordIface = c;
+                break;
+            }
+        }
+        if (cassandraRecordIface == null) {
+            throw new IllegalStateException("CassandraRecord interface not found in CassandraSource");
+        }
+
+        // Build a dynamic proxy that routes every CassandraRecord call to our RecordProxy.
+        final Class<?> ifaceClass = cassandraRecordIface;
+        InvocationHandler handler = (proxyObj, method, args) -> {
+            switch (method.getName()) {
+                case "getMutationMessage":    return proxy.msg;
+                case "getQueryResult":        return proxy.getQueryResult();
+                case "getConverterAndQuery":  return mockCaq;
+                case "getMutationKey":        return proxy.mutationKey;
+                case "getMutationValue":      return proxy.mutationValue;
+                case "getPk":                 return proxy.pk;
+                case "replaceQueryResult":
+                    proxy.setQueryResult((CompletableFuture<KeyValue<Object, Object>>) args[0]);
+                    return null;
+                // KVRecord / Record methods not needed by waitForCqlWithRetry — return defaults.
+                default:
+                    if (method.getReturnType() == boolean.class) return false;
+                    if (method.getReturnType() == int.class)     return 0;
+                    return null;
+            }
+        };
+        Object cassandraRecord = Proxy.newProxyInstance(
+                CassandraSource.class.getClassLoader(),
+                new Class[]{ifaceClass},
+                handler);
+
+        Method m = CassandraSource.class.getDeclaredMethod("waitForCqlWithRetry", ifaceClass);
+        m.setAccessible(true);
+        return (KeyValue<Object, Object>) m.invoke(source, cassandraRecord);
+    }
+
+    // ── reflection utilities ──────────────────────────────────────────────────────
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                Field f = clazz.getDeclaredField(name);
+                f.setAccessible(true);
+                f.set(target, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in " + target.getClass());
+    }
+
+    private static Object getField(Object target, String name) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                Field f = clazz.getDeclaredField(name);
+                f.setAccessible(true);
+                return f.get(target);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in " + target.getClass());
+    }
+
+    /**
+     * Holds the pre-decoded state for one test record and tracks the mutable
+     * {@code queryResult} future so the dynamic proxy can forward
+     * {@code getQueryResult}/{@code replaceQueryResult} correctly.
+     */
+    private static class RecordProxy {
+        final Message<KeyValue<org.apache.pulsar.client.api.schema.GenericRecord, MutationValue>> msg;
+        final org.apache.pulsar.client.api.schema.GenericRecord mutationKey;
+        final MutationValue mutationValue;
+        final List<Object> pk;
+        private final AtomicReference<CompletableFuture<KeyValue<Object, Object>>> queryResult =
+                new AtomicReference<>();
+
+        RecordProxy(
+                Message<KeyValue<org.apache.pulsar.client.api.schema.GenericRecord, MutationValue>> msg,
+                org.apache.pulsar.client.api.schema.GenericRecord mutationKey,
+                MutationValue mutationValue,
+                List<Object> pk) {
+            this.msg = msg;
+            this.mutationKey = mutationKey;
+            this.mutationValue = mutationValue;
+            this.pk = pk;
+        }
+
+        void setQueryResult(CompletableFuture<KeyValue<Object, Object>> future) {
+            queryResult.set(future);
+        }
+
+        CompletableFuture<KeyValue<Object, Object>> getQueryResult() {
+            return queryResult.get();
+        }
+    }
+}


### PR DESCRIPTION
- add unit tests for CQL query retry behavior

- add rate limiter, batch.maxWaitMs, and cgroup-aware CPU detection

- revisited query thread default and query max task queue default based on cpu 